### PR TITLE
tooltip: limit width relative to main window

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -642,7 +642,7 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 			int win_title_len = 0;
 			FcChar8 *win_title = wm_get_window_title(ps, cw->wid_client, &win_title_len);
 			if (win_title) {
-				tooltip_map(cw->mainwin->tooltip, cw->mini.width,
+				tooltip_map(cw->mainwin->tooltip,
 						ev->xcrossing.x_root, ev->xcrossing.y_root,
 						win_title, win_title_len);
 				free(win_title);

--- a/src/tooltip.c
+++ b/src/tooltip.c
@@ -163,17 +163,19 @@ tooltip_create(MainWin *mw) {
 }
 
 void
-tooltip_map(Tooltip *tt, int mini_width, int mouse_x, int mouse_y,
-		const FcChar8 *text, int len) {
+tooltip_map(Tooltip *tt, int mouse_x, int mouse_y,
+		const FcChar8 *text, int len)
+{
 	session_t * const ps = tt->mainwin->ps;
+	unsigned int max_width = tt->mainwin->width * 0.3;
 
 	XUnmapWindow(ps->dpy, tt->window);
 	
 	XftTextExtentsUtf8(ps->dpy, tt->font, text, len, &tt->extents);
 	
 	tt->width = tt->extents.width + 8;
-	if (tt->width > mini_width)
-		tt->width = mini_width;
+	if (tt->width > max_width)
+		tt->width = max_width;
 	tt->height = tt->font_height + 5 + (tt->shadow.pixel ? 2 : 0);
 	XResizeWindow(ps->dpy, tt->window, tt->width, tt->height);
 	tooltip_move(tt, mouse_x, mouse_y);

--- a/src/tooltip.h
+++ b/src/tooltip.h
@@ -39,7 +39,7 @@ typedef struct _Tooltip Tooltip;
 
 Tooltip *tooltip_create(MainWin *mw);
 void tooltip_destroy(Tooltip *);
-void tooltip_map(Tooltip *tt, int mini_width, int mouse_x, int mouse_y,
+void tooltip_map(Tooltip *tt, int mouse_x, int mouse_y,
 		const FcChar8 *text, int len);
 void tooltip_unmap(Tooltip *);
 void tooltip_handle(Tooltip *, XEvent *);


### PR DESCRIPTION
Truncating at preview width cuts off too much text from the window
title for small previews. Instead of using preview width, calculate
the width relative to the main window width.