### PR TITLE
Fixed pointer and live preview after animation.

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -738,9 +738,9 @@ mainloop(session_t *ps, bool activate_on_start) {
 				anime(ps->mainwin, ps->mainwin->clients,
 						((float)timeslice)/(float)ps->o.animationDuration);
 				if ( timeslice >= ps->o.animationDuration) {
-					XSync(ps->dpy, False);
 					animating = false;
 					last_rendered = time_in_millis();
+                    focus_miniw_adv(ps, mw->client_to_focus, ps->o.movePointerOnStart);
 				}
 
 			}

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -740,7 +740,8 @@ mainloop(session_t *ps, bool activate_on_start) {
 				if ( timeslice >= ps->o.animationDuration) {
 					animating = false;
 					last_rendered = time_in_millis();
-					focus_miniw_adv(ps, mw->client_to_focus, ps->o.movePointerOnStart);
+					focus_miniw_adv(ps, mw->client_to_focus,
+							ps->o.movePointerOnStart);
 				}
 
 			}

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -740,7 +740,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 				if ( timeslice >= ps->o.animationDuration) {
 					animating = false;
 					last_rendered = time_in_millis();
-                    focus_miniw_adv(ps, mw->client_to_focus, ps->o.movePointerOnStart);
+					focus_miniw_adv(ps, mw->client_to_focus, ps->o.movePointerOnStart);
 				}
 
 			}


### PR DESCRIPTION
Potentially related: when I press escape, no window is focused? Shouldn't behaviour be to focus on previously focused window?