### PR TITLE
Prev/Next window selection ordering

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -398,6 +398,11 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader) {
 	{
 		unsigned int newwidth = 0, newheight = 0;
 		layout_run(mw, mw->cod, &newwidth, &newheight);
+
+		// ordering of client windows list
+		// is important for prev/next window selection
+		dlist_sort(mw->cod, sort_cw_by_pos, 0);
+
 		float multiplier = (float) (mw->width - 100) / newwidth;
 		if (multiplier * newheight > mw->height - 100)
 			multiplier = (float) (mw->height - 100) / newheight;

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -1340,6 +1340,23 @@ report_key_modifiers(XKeyEvent *evk)
 #include "img-gif.h"
 #endif
 
+static inline int
+sort_cw_by_pos(dlist* dlist1, dlist* dlist2, void* data)
+{
+	ClientWin *cw1 = (ClientWin *) dlist1->data;
+	ClientWin *cw2 = (ClientWin *) dlist2->data;
+	if (cw1->y < cw2->y)
+		return -1;
+	else if (cw1->y > cw2->y)
+		return 1;
+	else if (cw1->x < cw2->x)
+		return -1;
+	else if (cw1->x > cw2->x)
+		return 1;
+	else
+		return 0;
+}
+
 extern session_t *ps_g;
 
 #endif /* SKIPPY_H */


### PR DESCRIPTION
This PR sorts the client windows list by order of left->right, top->bottom. This allows next/prev selection in the correct order.