### PR TITLE
Remove bogus mouse movement

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -478,11 +478,6 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader) {
 
 	}
 
-	// Unfortunately it does not work...
-	// focus_miniw_adv(ps, mw->focus, ps->o.movePointerOnStart);
-	focus_miniw_adv(ps, mw->client_to_focus, ps->o.movePointerOnStart);
-	// clientwin_render(mw->client_to_focus);
-
 	return clients;
 }
 


### PR DESCRIPTION
Pointer focus is now done at the completion of animation, so no need for pointer focus before animation