### PR TITLE
Alt-Tab requires window order based on stack

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -453,9 +453,9 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader) {
 		// is important for prev/next window selection
 		dlist_sort(mw->cod, sort_cw_by_pos, 0);
 
-		float multiplier = (float) (mw->width - 100) / newwidth;
-		if (multiplier * newheight > mw->height - 100)
-			multiplier = (float) (mw->height - 100) / newheight;
+		float multiplier = (float) (mw->width - 2 * mw->distance) / newwidth;
+		if (multiplier * newheight > mw->height - 2 * mw->distance)
+			multiplier = (float) (mw->height - 2 * mw->distance) / newheight;
 		if (!ps->o.allowUpscale)
 			multiplier = MIN(multiplier, 1.0f);
 
@@ -477,11 +477,6 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader) {
 	foreach_dlist(mw->cod) {
 		clientwin_update2((ClientWin *) iter->data);
 	}
-
-	// Unfortunately it does not work...
-	// focus_miniw_adv(ps, mw->focus, ps->o.movePointerOnStart);
-	focus_miniw_adv(ps, mw->client_to_focus, ps->o.movePointerOnStart);
-	// clientwin_render(mw->client_to_focus);
 
 	return clients;
 }

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -394,40 +394,6 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader) {
 	
 	dlist_sort(mw->cod, clientwin_sort_func, 0);
 
-	/* Move the mini windows around */
-	{
-		unsigned int newwidth = 0, newheight = 0;
-		layout_run(mw, mw->cod, &newwidth, &newheight);
-
-		// ordering of client windows list
-		// is important for prev/next window selection
-		dlist_sort(mw->cod, sort_cw_by_pos, 0);
-
-		float multiplier = (float) (mw->width - 100) / newwidth;
-		if (multiplier * newheight > mw->height - 100)
-			multiplier = (float) (mw->height - 100) / newheight;
-		if (!ps->o.allowUpscale)
-			multiplier = MIN(multiplier, 1.0f);
-
-		int xoff = (mw->width - (float) newwidth * multiplier) / 2;
-		int yoff = (mw->height - (float) newheight * multiplier) / 2;
-
-		mw->multiplier = multiplier;
-		mw->xoff = xoff;
-		mw->yoff = yoff;
-		mw->newwidth = newwidth;
-		mw->newheight = newheight;
-
-		mainwin_transform(mw, multiplier);
-		foreach_dlist (mw->cod) {
-			clientwin_move((ClientWin *) iter->data, multiplier, xoff, yoff, 0);
-		}
-	}
-
-	foreach_dlist(mw->cod) {
-		clientwin_update2((ClientWin *) iter->data);
-	}
-
 	// Get the currently focused window and select which mini-window to focus
 	{
 		dlist *iter = dlist_find(mw->cod, clientwin_cmp_func, (void *) focus);
@@ -476,6 +442,40 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader) {
 		mw->client_to_focus->focused = 1;
 		// focus_miniw(ps, mw->client_to_focus);
 
+	}
+
+	/* Move the mini windows around */
+	{
+		unsigned int newwidth = 0, newheight = 0;
+		layout_run(mw, mw->cod, &newwidth, &newheight);
+
+		// ordering of client windows list
+		// is important for prev/next window selection
+		dlist_sort(mw->cod, sort_cw_by_pos, 0);
+
+		float multiplier = (float) (mw->width - 100) / newwidth;
+		if (multiplier * newheight > mw->height - 100)
+			multiplier = (float) (mw->height - 100) / newheight;
+		if (!ps->o.allowUpscale)
+			multiplier = MIN(multiplier, 1.0f);
+
+		int xoff = (mw->width - (float) newwidth * multiplier) / 2;
+		int yoff = (mw->height - (float) newheight * multiplier) / 2;
+
+		mw->multiplier = multiplier;
+		mw->xoff = xoff;
+		mw->yoff = yoff;
+		mw->newwidth = newwidth;
+		mw->newheight = newheight;
+
+		mainwin_transform(mw, multiplier);
+		foreach_dlist (mw->cod) {
+			clientwin_move((ClientWin *) iter->data, multiplier, xoff, yoff, 0);
+		}
+	}
+
+	foreach_dlist(mw->cod) {
+		clientwin_update2((ClientWin *) iter->data);
 	}
 
 	// Unfortunately it does not work...


### PR DESCRIPTION
Preivous PR https://github.com/dreamcat4/skippy-xd/pull/27 orders windows based on window layout/positioning, so that prev/next movement moves row-by-row. (A newer PR moves column-by-column: https://github.com/dreamcat4/skippy-xd/pull/29)

For Alt-Tab usage of skippy-xd, a user would want either a quick Alt-Tab on the previous window selected, and longer duration of skippy-xd invocation for actual selection based on next/prev. To enable this usage, the window to focus should be set/stored BEFORE sorting of the list of client windows, the latter dictating subsequent prev/next selection.

I have not tested this code, since I don't use skippy-xd as Alt-Tab. @dreamcat4 can you please test? These features are not relevant to my personal usage, but I would be happy if the project continues as a mature tool. I think many people would like a mature light-weight expose tool. I am happy to contribute but I can't do everything myself, at the minimum someone has to test :)