### PR TITLE
Roundoff

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -425,7 +425,6 @@ clientwin_move(ClientWin *cw, float f, int x, int y, float timeslice)
 		cw->mini.width = (float) cw->src.width * f;
 		cw->mini.height = (float) cw->src.height * f;
 	}
-	printfdf("(): window %p coord: (%d,%d) (%d,%d)", cw, cw->mini.x, cw->mini.y, cw->mini.width, cw->mini.height);
 
 	XMoveResizeWindow(cw->mainwin->ps->dpy, cw->mini.window, cw->mini.x - border, cw->mini.y - border, cw->mini.width, cw->mini.height);
 	

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -408,8 +408,8 @@ clientwin_move(ClientWin *cw, float f, int x, int y, float timeslice)
 	XSetWindowBorderWidth(cw->mainwin->ps->dpy, cw->mini.window, border);
 
 	cw->factor = f;
-	cw->mini.x = x + (int)cw->x * f;
-	cw->mini.y = y + (int)cw->y * f;
+	cw->mini.x = x + (float) cw->x * f;
+	cw->mini.y = y + (float) cw->y * f;
 	if(cw->mainwin->ps->o.lazyTrans)
 	{
 		cw->mini.x += cw->mainwin->x;
@@ -420,11 +420,12 @@ clientwin_move(ClientWin *cw, float f, int x, int y, float timeslice)
 		// animate window by changing these in time linearly:
 		// here, cw->mini has destination coordinates, cw->src has original coordinates
 
-		cw->mini.x = cw->src.x + (cw->mini.x - cw->src.x) * timeslice;
-		cw->mini.y = cw->src.y + (cw->mini.y - cw->src.y) * timeslice;
-		cw->mini.width = cw->src.width * f;
-		cw->mini.height = cw->src.height * f;
+		cw->mini.x = cw->src.x + (float) (cw->mini.x - cw->src.x) * timeslice;
+		cw->mini.y = cw->src.y + (float) (cw->mini.y - cw->src.y) * timeslice;
+		cw->mini.width = (float) cw->src.width * f;
+		cw->mini.height = (float) cw->src.height * f;
 	}
+	printfdf("(): window %p coord: (%d,%d) (%d,%d)", cw, cw->mini.x, cw->mini.y, cw->mini.width, cw->mini.height);
 
 	XMoveResizeWindow(cw->mainwin->ps->dpy, cw->mini.window, cw->mini.x - border, cw->mini.y - border, cw->mini.width, cw->mini.height);
 	

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -744,7 +744,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 				anime(ps->mainwin, ps->mainwin->clients,
 						((float)timeslice)/(float)ps->o.animationDuration);
 				if ( timeslice >= ps->o.animationDuration) {
-                    anime(ps->mainwin, ps->mainwin->clients, 1);
+					anime(ps->mainwin, ps->mainwin->clients, 1);
 					animating = false;
 					last_rendered = time_in_millis();
 					focus_miniw_adv(ps, mw->client_to_focus,

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -744,6 +744,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 				anime(ps->mainwin, ps->mainwin->clients,
 						((float)timeslice)/(float)ps->o.animationDuration);
 				if ( timeslice >= ps->o.animationDuration) {
+                    anime(ps->mainwin, ps->mainwin->clients, 1);
 					animating = false;
 					last_rendered = time_in_millis();
 					focus_miniw_adv(ps, mw->client_to_focus,


### PR DESCRIPTION
Without a final animation at time 1, the time might be slightly off, so the window layout position would be slightly off.

In addition to not being perfectly aligned, the windows might overlap, and that messes up focus_up(), focus_down(), focus_left(), focus_right(). These functions assume windows never overlap, and ultimately affects windows selection.