### PR TITLE
add: can now keep local custom user rc file ./skippy-xd.rc in-repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ man/*.1
 doxygen/
 .clang_complete
 /src/backtrace-symbols.[ch]
+
+# User config override
+skippy-xd.rc*

--- a/Makefile
+++ b/Makefile
@@ -83,12 +83,23 @@ install-check:
 	@echo "'make install' target folders:"
 	@echo "PREFIX=${PREFIX} DESTDIR=${DESTDIR} BINDIR=${BINDIR}"
 	@echo "skippy executables will be installed into: ${DESTDIR}${BINDIR}"
-	@echo "skippy's config file will be installed to: ${DESTDIR}/etc/xdg/skippy-xd.rc"
 
 install: ${BINS} skippy-xd.sample.rc
 	install -d "${DESTDIR}${BINDIR}/" "${DESTDIR}/etc/xdg/"
 	install -m 755 ${BINS} "${DESTDIR}${BINDIR}/"
+
+ifneq ("$(wildcard skippy-xd.rc)","")
+	@echo "your custom skippy config file will be installed to: ${DESTDIR}/etc/xdg/skippy-xd.rc"
+	install -m 644 skippy-xd.rc "${DESTDIR}/etc/xdg/skippy-xd.rc"
+
+	@echo "skippy's sample config file will be installed to: ${DESTDIR}/etc/xdg/skippy-xd.sample.rc"
+	install -m 644 skippy-xd.sample.rc "${DESTDIR}/etc/xdg/skippy-xd.sample.rc"
+else
+	@echo "skippy's default config file will be installed to: ${DESTDIR}/etc/xdg/skippy-xd.rc"
 	install -m 644 skippy-xd.sample.rc "${DESTDIR}/etc/xdg/skippy-xd.rc"
+	install -m 644 skippy-xd.sample.rc "${DESTDIR}/etc/xdg/skippy-xd.sample.rc"
+endif
+
 	install -m 755 skippy-xd-runner "${DESTDIR}${BINDIR}/"
 
 uninstall:


### PR DESCRIPTION
This changes should not conflict with any other recent ongoing / pending work. It merely adds capability to 


add: can now keep local custom user rc file ./skippy-xd.rc in-repo
(this custom user file is .gitignored)

if found / detected (optional file exists) --> then `make install` will give priority and install it into /etc/xdg/
if not found (default) --> then `make install` will just copy the default sample rc instead (as always)

example usage:

```sh
$ make
$ cp ./skippy-xd.sample.rc ./skippy-xd.rc

# edit your skippy-xd.rc file in-repo, it will be ignored by git

$ sudo make install
your custom skippy config file will be installed to: /etc/xdg/skippy-xd.rc
install -m 644 skippy-xd.rc "/etc/xdg/skippy-xd.rc"
skippy's sample config file will be installed to: /etc/xdg/skippy-xd.sample.rc
install -m 644 skippy-xd.sample.rc "/etc/xdg/skippy-xd.sample.rc"
```


Possible missing functionality / limitation:

* if you want to instead put a symlink from another location (outside your working tree). So that it is then picked up into your local working tree. Then `install` command might just copy the symlink itself, rather than follow where the symlink goes, to copy the source file elsewhere in other location.