### PR TITLE
Memleak

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -193,6 +193,8 @@ clientwin_update(ClientWin *cw) {
 	}
 
 	// Get window icon
+	if (cw->icon_pict)
+		free_pictw(ps, &cw->icon_pict);
 	cw->icon_pict = simg_load_icon(ps, cw->wid_client, ps->o.preferredIconSize);
 	if (!cw->icon_pict && ps->o.iconDefault)
 		cw->icon_pict = clone_pictw(ps, ps->o.iconDefault);
@@ -215,6 +217,8 @@ clientwin_update(ClientWin *cw) {
 
 static inline bool
 clientwin_update2_filled(session_t *ps, MainWin *mw, ClientWin *cw) {
+	if (cw->pict_filled)
+		free_pictw(ps, &cw->pict_filled);
 	cw->pict_filled = simg_postprocess(ps,
 			clone_pictw(ps, ps->o.fillSpec.img),
 			ps->o.fillSpec.mode,
@@ -226,6 +230,8 @@ clientwin_update2_filled(session_t *ps, MainWin *mw, ClientWin *cw) {
 
 static inline bool
 clientwin_update2_icon(session_t *ps, MainWin *mw, ClientWin *cw) {
+	if (cw->icon_pict_filled)
+		free_pictw(ps, &cw->icon_pict_filled);
 	cw->icon_pict_filled = simg_postprocess(ps,
 			clone_pictw(ps, cw->icon_pict),
 			ps->o.iconFillSpec.mode,

--- a/src/layout.c
+++ b/src/layout.c
@@ -571,6 +571,8 @@ move_window:
 	}
 
 	if (recalculate) {
+		for (int i=0; i<number_of_slots; i++)
+			dlist_free (slot2cw[i]);
 		free(slot2cw);
 		free(slot2n);
 	}
@@ -634,6 +636,9 @@ move_window:
 	*total_width = maxx - minx;
 	*total_height = maxy - miny;
 
+	for (int j=slot_miny; j<slot_maxy; j++)
+		for (int i=slot_minx; i<slot_maxx; i++)
+			dlist_free (slot2cw[(j-slot_miny) * (slot_maxx - slot_minx) + i-slot_minx]);
 	free(slot2cw);
 	free(slot2n);
 }

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -472,6 +472,8 @@ mainwin_destroy(MainWin *mw) {
 	free(mw->keysyms_Down);
 	free(mw->keysyms_Left);
 	free(mw->keysyms_Right);
+	free(mw->keysyms_Prev);
+	free(mw->keysyms_Next);
 	free(mw->keysyms_ExitCancelOnPress);
 	free(mw->keysyms_ExitCancelOnRelease);
 	free(mw->keysyms_ExitSelectOnPress);

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -1100,6 +1100,7 @@ check_keybindings_conflict(const char *config_path, const char *arr1_str, KeySym
     free(conflicts);
     return true;
   }
+  free(conflicts);
   return false;
 }
 

--- a/src/wm.c
+++ b/src/wm.c
@@ -456,6 +456,7 @@ return_status:
 	if (status == Success && items_read && data && real_format == 32)
 		num_desktops = data[0];
 
+	XFree(data);
 	return num_desktops;
 }
 


### PR DESCRIPTION
Please test just in case this causes regressions/segfaults.

There is still one leak of 24 bytes that I have not bothered fixing:

==24987== 192 (24 direct, 168 indirect) bytes in 1 blocks are definitely lost in loss record 65 of 89
==24987==    at 0x4841888: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==24987==    by 0x116A10: dlist_add (dlist.c:47)
==24987==    by 0x116A10: dlist_find_all (dlist.c:456)
==24987==    by 0x10DB52: daemon_count_clients.constprop.0 (skippy.c:350)
==24987==    by 0x112968: mainloop (skippy.c:905)
==24987==    by 0x10D38C: main (skippy.c:1824)