### PR TITLE
Removed 1-2 xerrors

### DIFF
--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -66,37 +66,8 @@ struct _clientwin_t {
 	.mainwin = NULL \
 }
 
-static inline client_disp_mode_t
-clientwin_get_disp_mode(session_t *ps, ClientWin *cw) {
-	XWindowAttributes wattr = { };
-	XGetWindowAttributes(ps->dpy, cw->src.window, &wattr);
-
-	for (client_disp_mode_t *p = ps->o.clientDisplayModes; *p; p++) {
-		switch (*p) {
-			case CLIDISP_THUMBNAIL_ICON:
-				if (IsViewable == wattr.map_state && cw->origin && cw->icon_pict)
-					return *p;
-				break;
-			case CLIDISP_THUMBNAIL:
-				if (IsViewable == wattr.map_state && cw->origin) return *p;
-				break;
-			case CLIDISP_ZOMBIE_ICON:
-				if (cw->shadow && cw->icon_pict != NULL) return *p;
-				break;
-			case CLIDISP_ZOMBIE:
-				if (cw->shadow) return *p;
-				break;
-			case CLIDISP_ICON:
-				if (cw->icon_pict) return *p;
-				break;
-			case CLIDISP_FILLED:
-			case CLIDISP_NONE:
-				return *p;
-		}
-	}
-
-	return CLIDISP_NONE;
-}
+client_disp_mode_t
+clientwin_get_disp_mode(session_t *ps, ClientWin *cw, bool isViewable);
 
 static inline void
 clientwin_free_res2(session_t *ps, ClientWin *cw) {

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -292,8 +292,7 @@ update_clients(MainWin *mw, Bool *touched)
 	// Terminate mw->clients that are no longer managed
 	for (dlist *iter = mw->clients; iter; ) {
 		ClientWin *cw = (ClientWin *) iter->data;
-		if (dlist_find_data(stack, (void *) cw->wid_client)
-				/*&& clientwin_update(cw)*/) {
+		if (dlist_find_data(stack, (void *) cw->wid_client)) {
 			iter = iter->next;
 		}
 		else {
@@ -315,7 +314,6 @@ update_clients(MainWin *mw, Bool *touched)
 			cw = clientwin_create(mw, (Window)iter->data);
 			if (!cw) continue;
 			mw->clients = dlist_add(mw->clients, cw);
-			/*clientwin_update(cw)*/;
 			if (touched)
 				*touched = True;
 		}
@@ -344,8 +342,8 @@ daemon_count_clients(MainWin *mw, Bool *touched, Window leader)
 	mw->clientondesktop = NULL;
 
 	{
-        session_t * const ps = mw->ps;
-        long desktop = wm_get_current_desktop(ps);
+		session_t * const ps = mw->ps;
+		long desktop = wm_get_current_desktop(ps);
 
 		dlist *tmp = dlist_first(dlist_find_all(mw->clients,
 					(dlist_match_func) clientwin_validate_func, &desktop));
@@ -900,14 +898,13 @@ mainloop(session_t *ps, bool activate_on_start) {
 					}
 				}
 				else if (ev.type == MapNotify || ev.type == UnmapNotify) {
-					//printfef("(): else if (ev.type == MapNotify || ev.type == UnmapNotify) {");
+					// printfef("(): else if (ev.type == MapNotify || ev.type == UnmapNotify) {");
 					daemon_count_clients(ps->mainwin, 0, None);
 					dlist *iter = (wid ? dlist_find(ps->mainwin->clients, clientwin_cmp_func, (void *) wid): NULL);
 					if (iter) {
 						ClientWin *cw = (ClientWin *) iter->data;
 						clientwin_update(cw);
 						clientwin_update2(cw);
-						clientwin_render(cw);
 					}
 				}
 				else if (mw && (ps->xinfo.damage_ev_base + XDamageNotify == ev.type)) {


### PR DESCRIPTION
I still experience some x errors, due to my WM not sending the UnmapNotify rather than DestroyNotify signal. Then clientwin_update() would be called, and the xlib calls would give xerrors.

According to https://stackoverflow.com/questions/44025639/how-can-i-check-in-xlib-if-window-exists, there is nothing we can do about it, other than not being so verbose with xerrors #52.