### PR TITLE
Prints

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -243,7 +243,7 @@ clientwin_update(ClientWin *cw) {
 	// if we ever got a thumbnail for the window,
 	// the mode for that window always will be thumbnail
 	cw->mode = clientwin_get_disp_mode(ps, cw, isViewable);
-	printfdf(false, "(%#010lx): %d", cw->wid_client, cw->mode);
+	printfdf(false, "(): (%#010lx): %d", cw->wid_client, cw->mode);
 
 	return true;
 }

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -243,7 +243,7 @@ clientwin_update(ClientWin *cw) {
 	// if we ever got a thumbnail for the window,
 	// the mode for that window always will be thumbnail
 	cw->mode = clientwin_get_disp_mode(ps, cw, isViewable);
-	// printfdf("(%#010lx): %d", cw->wid_client, cw->mode);
+	printfdf(false, "(%#010lx): %d", cw->wid_client, cw->mode);
 
 	return true;
 }
@@ -548,8 +548,6 @@ childwin_focus(ClientWin *cw) {
 
 int
 clientwin_handle(ClientWin *cw, XEvent *ev) {
-	// printfef("(): ");
-
 	if (! cw)
 		return 1;
 
@@ -560,9 +558,9 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 
 	if (ev->type == KeyPress)
 	{
-		//report_key(ev);
-		//report_key_modifiers(evk);
-		fputs("\n", stdout); fflush(stdout);
+		report_key(ev);
+		report_key_modifiers(evk);
+		if (debuglog) fputs("\n", stdout);
 
 		bool reverse_direction = false;
 
@@ -620,7 +618,6 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_ExitCancelOnPress, evk->keycode))
 		{
-			//printfef("(): Quitting.");
 			mw->client_to_focus = mw->client_to_focus_on_cancel;
 			return 1;
 		}
@@ -633,24 +630,20 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 	}
 	else if (ev->type == KeyRelease)
 	{
-		// report_key(ev);
-
-		//report_key(ev);
-		//report_key_modifiers(evk);
-		// fputs("\n", stdout); fflush(stdout);
+		report_key(ev);
+		report_key_modifiers(evk);
+		if (debuglog) fputs("\n", stdout);
 
 		if (arr_keycodes_includes(cw->mainwin->keycodes_ExitSelectOnRelease, evk->keycode))
 		{
-			// printfef("(): if (arr_keycodes_includes(cw->mainwin->keycodes_ExitSelectOnRelease, evk->keycode))");
-			// printfef("(): client_to_focus = %p", (uintptr_t)ps->mainwin->client_to_focus);
+			printfdf(false, "(): if (arr_keycodes_includes(cw->mainwin->keycodes_ExitSelectOnRelease, evk->keycode))");
+			printfdf(false, "(): client_to_focus = %p", ps->mainwin->client_to_focus);
 			// mw->client_to_focus = cw;
-			// printfef("(): client_to_focus = %p", (uintptr_t)ps->mainwin->client_to_focus);
 			return 1;
 		}
 
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_ExitCancelOnRelease, evk->keycode))
 		{
-			//printfef("(): Quitting.");
 			return 1;
 		}
 	}
@@ -661,32 +654,30 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 			cw->mainwin->pressed = cw; */
 	}
 	else if (ev->type == ButtonRelease) {
-		// printfef("(): else if (ev->type == ButtonRelease) {");
 		const unsigned button = ev->xbutton.button;
 		if (cw->mainwin->pressed_mouse) {
 			if (button < MAX_MOUSE_BUTTONS) {
 				int ret = clientwin_action(cw,
 						ps->o.bindings_miwMouse[button]);
 				if (ret) {
-					//printfef("(): Quitting.");
 					return ret;
 				}
 			}
 		}
-		//else
-			//printfef("(): ButtonRelease %u ignored.", button);
+		else
+			printfdf(false, "(): ButtonRelease %u ignored.", button);
 	}
 
 	else if (ev->type == FocusIn) {
-		//printfef("(): else if (ev->type == FocusIn) {");
+		printfdf(false, "(): else if (ev->type == FocusIn) {");
 		XFocusChangeEvent *evf = &ev->xfocus;
 
 		// for debugging XEvents
 		// see: https://tronche.com/gui/x/xlib/events/input-focus/normal-and-grabbed.html
-		//printfef("(): main window id = %#010lx", cw->mainwin->window);
-		//printfefWindowName(ps, "(): client window = ", cw->mainwin->window);
-		//printfef("(): client window id = %#010lx", cw->wid_client);
-		//printfefXFocusChangeEvent(ps, evf);
+		printfdf(false, "(): main window id = %#010lx", cw->mainwin->window);
+		printfdfWindowName(ps, "(): client window = ", cw->mainwin->window);
+		printfdf(false, "(): client window id = %#010lx", cw->wid_client);
+		printfdfXFocusChangeEvent(ps, evf);
 
 		// printfef("(): usleep(10000);");
 		// usleep(10000);
@@ -696,19 +687,19 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 			cw->focused = true;
 
 		clientwin_render(cw);
-		fputs("\n", stdout);
+		if (debuglog) fputs("\n", stdout);
 		XFlush(ps->dpy);
 
 	} else if (ev->type == FocusOut) {
-		//printfef("(): else if (ev->type == FocusOut) {");
+		printfdf(false, "(): else if (ev->type == FocusOut) {");
 		XFocusChangeEvent *evf = &ev->xfocus;
 
 		// for debugging XEvents
 		// see: https://tronche.com/gui/x/xlib/events/input-focus/normal-and-grabbed.html
-		//printfef("(): main window id = %#010lx", cw->mainwin->window);
-		//printfefWindowName(ps, "(): client window = ", cw->mainwin->window);
-		//printfef("(): client window id = %#010lx", cw->wid_client);
-		//printfefXFocusChangeEvent(ps, evf);
+		printfdf(false, "(): main window id = %#010lx", cw->mainwin->window);
+		printfdfWindowName(ps, "(): client window = ", cw->mainwin->window);
+		printfdf(false, "(): client window id = %#010lx", cw->wid_client);
+		printfdfXFocusChangeEvent(ps, evf);
 
 		// printfef("(): usleep(10000);");
 		// usleep(10000);
@@ -718,7 +709,7 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 			cw->focused = false;
 
 		clientwin_render(cw);
-		fputs("\n", stdout);
+		if (debuglog) fputs("\n", stdout);
 		XFlush(ps->dpy);
 
 	} else if(ev->type == EnterNotify) {
@@ -753,7 +744,6 @@ clientwin_action(ClientWin *cw, enum cliop action) {
 		case CLIENTOP_NO:
 			break;
 		case CLIENTOP_FOCUS:
-			//printfef("(): case CLIENTOP_FOCUS:");
 			mw->client_to_focus = cw;
 			return 1;
 		case CLIENTOP_ICONIFY:

--- a/src/config.c
+++ b/src/config.c
@@ -93,7 +93,7 @@ config_parse(const char *config) {
 				     *value = copy_match(line, &matches[2]);
 				new_config = entry_set(new_config, section, key, value);
 			} else  {
-				printfef(true, "WARNING: Ignoring invalid line: %s\n", line);
+				printfef(true, "(): WARNING: Ignoring invalid line: %s\n", line);
 			}
 			l_ix = 0;
 		} else {
@@ -125,7 +125,7 @@ config_load(const char *path)
 	
 	if(! fin)
 	{
-		printfef(true, "WARNING: Couldn't load config file '%s'.\n", path);
+		printfef(true, "(): WARNING: Couldn't load config file '%s'.\n", path);
 		return 0;
 	}
 	else
@@ -138,7 +138,7 @@ config_load(const char *path)
 	
 	if(! flen)
 	{
-		printfef(true, "WARNING: '%s' is empty.\n", path);
+		printfef(true, "(): WARNING: '%s' is empty.\n", path);
 		fclose(fin);
 		return 0;
 	}
@@ -149,7 +149,7 @@ config_load(const char *path)
 	data[flen] = '\0';
 	if(fread(data, 1, flen, fin) != flen)
 	{
-		printfef(true, "WARNING: Couldn't read from config file '%s'.\n", path);
+		printfef(true, "(): WARNING: Couldn't read from config file '%s'.\n", path);
 		free(data);
 		fclose(fin);
 		return 0;

--- a/src/config.c
+++ b/src/config.c
@@ -93,7 +93,7 @@ config_parse(const char *config) {
 				     *value = copy_match(line, &matches[2]);
 				new_config = entry_set(new_config, section, key, value);
 			} else  {
-				fprintf(stderr, "WARNING: Ignoring invalid line: %s\n", line);
+				printfef(true, "WARNING: Ignoring invalid line: %s\n", line);
 			}
 			l_ix = 0;
 		} else {
@@ -125,12 +125,12 @@ config_load(const char *path)
 	
 	if(! fin)
 	{
-		fprintf(stderr, "WARNING: Couldn't load config file '%s'.\n", path);
+		printfef(true, "WARNING: Couldn't load config file '%s'.\n", path);
 		return 0;
 	}
 	else
 	{
-		printfef("(): config file found. using \"%s\"", path);
+		printfef(true, "(): config file found. using \"%s\"", path);
 	}
 	
 	fseek(fin, 0, SEEK_END);
@@ -138,7 +138,7 @@ config_load(const char *path)
 	
 	if(! flen)
 	{
-		fprintf(stderr, "WARNING: '%s' is empty.\n", path);
+		printfef(true, "WARNING: '%s' is empty.\n", path);
 		fclose(fin);
 		return 0;
 	}
@@ -149,7 +149,7 @@ config_load(const char *path)
 	data[flen] = '\0';
 	if(fread(data, 1, flen, fin) != flen)
 	{
-		fprintf(stderr, "WARNING: Couldn't read from config file '%s'.\n", path);
+		printfef(true, "WARNING: Couldn't read from config file '%s'.\n", path);
 		free(data);
 		fclose(fin);
 		return 0;

--- a/src/config.h
+++ b/src/config.h
@@ -41,7 +41,7 @@ config_get_bool(dlist *config, const char *section, const char *key,
 		return true;
 	if (!strcasecmp("false", result))
 		return false;
-	printfe("(%s, %s, %d): Unrecogized boolean value \"%s\".",
+	printfef(true, "(%s, %s, %d): Unrecogized boolean value \"%s\".",
 			section, key, def, result);
 	return def;
 }
@@ -67,17 +67,17 @@ config_get_int(dlist *config, const char *section, const char *key,
 	char *endptr = NULL;
 	int iresult = strtol(result, &endptr, 0);
 	if (!endptr || (*endptr && !isspace(*endptr))) {
-		printfef("(%s, %s, %d): Value \"%s\" is not a valid integer.",
+		printfef(true, "(%s, %s, %d): Value \"%s\" is not a valid integer.",
 			section, key, def, result);
 		return def;
 	}
 	if (iresult > max) {
-		printfef("(%s, %s, %d): Value \"%s\" larger than maximum value %d.",
+		printfef(true, "(%s, %s, %d): Value \"%s\" larger than maximum value %d.",
 			section, key, def, result, max);
 		return max;
 	}
 	if (iresult < min) {
-		printfef("(%s, %s, %d): Value \"%s\" smaller than minimal value %d.",
+		printfef(true, "(%s, %s, %d): Value \"%s\" smaller than minimal value %d.",
 			section, key, def, result, min);
 		return min;
 	}
@@ -105,17 +105,17 @@ config_get_double(dlist *config, const char *section, const char *key,
 	char *endptr = NULL;
 	double dresult = strtod(result, &endptr);
 	if (!endptr || (*endptr && !isspace(*endptr))) {
-		printfef("(%s, %s, %f): Value \"%s\" is not a valid floating-point number.",
+		printfef(true, "(%s, %s, %f): Value \"%s\" is not a valid floating-point number.",
 			section, key, def, result);
 		return def;
 	}
 	if (dresult > max) {
-		printfef("(%s, %s, %f): Value \"%s\" larger than maximum value %f.",
+		printfef(true, "(%s, %s, %f): Value \"%s\" larger than maximum value %f.",
 			section, key, def, result, max);
 		return max;
 	}
 	if (dresult < min) {
-		printfef("(%s, %s, %f): Value \"%s\" smaller than minimal value %f.",
+		printfef(true, "(%s, %s, %f): Value \"%s\" smaller than minimal value %f.",
 			section, key, def, result, min);
 		return min;
 	}

--- a/src/dlist.c
+++ b/src/dlist.c
@@ -141,7 +141,7 @@ dlist_insert_nth(dlist *l, dlist *new_elem, unsigned int n)
 	else
 	{
 		// there is no nth element
-		printfef(false, "(%p,%p,%i): list has fewer than %i elements. appending as the last element.", l, new_elem, n, n);
+		printfef(false, "(): (%p,%p,%i): list has fewer than %i elements. appending as the last element.", l, new_elem, n, n);
 		first_elem = dlist_insert_after( dlist_last(l), new_elem);
 	}
 

--- a/src/dlist.c
+++ b/src/dlist.c
@@ -141,7 +141,7 @@ dlist_insert_nth(dlist *l, dlist *new_elem, unsigned int n)
 	else
 	{
 		// there is no nth element
-		printfef("(%p,%p,%i): list has fewer than %i elements. appending as the last element.", l, new_elem, n, n);
+		printfef(false, "(%p,%p,%i): list has fewer than %i elements. appending as the last element.", l, new_elem, n, n);
 		first_elem = dlist_insert_after( dlist_last(l), new_elem);
 	}
 

--- a/src/focus.h
+++ b/src/focus.h
@@ -21,40 +21,54 @@
 #define SKIPPY_FOCUS_H
 
 static inline void
-printfefXFocusChangeEvent(session_t *ps, XFocusChangeEvent *evf)
+printfdfXFocusChangeEvent(session_t *ps, XFocusChangeEvent *evf)
 {
-	printfefWindowName(ps, "(): event window = ", evf->window);
-	printfef("(): event window id = %#010lx", evf->window);
+	printfdfWindowName(ps, "(): event window = ", evf->window);
+	printfdf(false, "(): event window id = %#010lx", evf->window);
 
-	if(evf->mode == NotifyNormal)
-		printfef("(): evf->mode = NotifyNormal");
-	else if(evf->mode == NotifyGrab)
-		printfef("(): evf->mode = NotifyGrab");
-	else if(evf->mode == NotifyUngrab)
-		printfef("(): evf->mode = NotifyUngrab");
-	else if(evf->mode == NotifyWhileGrabbed)
-		printfef("(): evf->mode = NotifyWhileGrabbed");
-	else
-		printfef("(): evf->mode = %i (not recognized)", evf->mode);
+	if(evf->mode == NotifyNormal) {
+		printfdf(false, "(): evf->mode = NotifyNormal");
+	}
+	else if(evf->mode == NotifyGrab) {
+		printfdf(false, "(): evf->mode = NotifyGrab");
+	}
+	else if(evf->mode == NotifyUngrab) {
+		printfdf(false, "(): evf->mode = NotifyUngrab");
+	}
+	else if(evf->mode == NotifyWhileGrabbed) {
+		printfdf(false, "(): evf->mode = NotifyWhileGrabbed");
+	}
+	else {
+		printfdf(false, "(): evf->mode = %i (not recognized)", evf->mode);
+	}
 
-	if(evf->detail == NotifyAncestor)
-		printfef("(): evf->detail = NotifyAncestor");
-	else if(evf->detail == NotifyVirtual)
-		printfef("(): evf->detail = NotifyVirtual");
-	else if(evf->detail == NotifyInferior)
-		printfef("(): evf->detail = NotifyInferior");
-	else if(evf->detail == NotifyNonlinear)
-		printfef("(): evf->detail = NotifyNonlinear");
-	else if(evf->detail == NotifyNonlinearVirtual)
-		printfef("(): evf->detail = NotifyNonlinearVirtual");
-	else if(evf->detail == NotifyPointer)
-		printfef("(): evf->detail = NotifyPointer");
-	else if(evf->detail == NotifyPointerRoot)
-		printfef("(): evf->detail = NotifyPointerRoot");
-	else if(evf->detail == NotifyDetailNone)
-		printfef("(): evf->detail = NotifyDetailNone");
-	else
-		printfef("(): evf->detail = %i (not recognized)", evf->detail);
+	if(evf->detail == NotifyAncestor) {
+		printfdf(false, "(): evf->detail = NotifyAncestor");
+	}
+	else if(evf->detail == NotifyVirtual) {
+		printfdf(false, "(): evf->detail = NotifyVirtual");
+	}
+	else if(evf->detail == NotifyInferior) {
+		printfdf(false, "(): evf->detail = NotifyInferior");
+	}
+	else if(evf->detail == NotifyNonlinear) {
+		printfdf(false, "(): evf->detail = NotifyNonlinear");
+	}
+	else if(evf->detail == NotifyNonlinearVirtual) {
+		printfdf(false, "(): evf->detail = NotifyNonlinearVirtual");
+	}
+	else if(evf->detail == NotifyPointer) {
+		printfdf(false, "(): evf->detail = NotifyPointer");
+	}
+	else if(evf->detail == NotifyPointerRoot) {
+		printfdf(false, "(): evf->detail = NotifyPointerRoot");
+	}
+	else if(evf->detail == NotifyDetailNone) {
+		printfdf(false, "(): evf->detail = NotifyDetailNone");
+	}
+	else {
+		printfdf(false, "(): evf->detail = %i (not recognized)", evf->detail);
+	}
 }
 
 static inline void
@@ -75,18 +89,16 @@ clear_focus_all(dlist *focuslist)
  */
 static inline void
 focus_miniw_adv(session_t *ps, ClientWin *cw, bool move_ptr) {
-	// printfef("(): ");
-
 	if (!cw || !ps)
 		return;
 
 	clear_focus_all(cw->mainwin->focuslist);
 
-	//printfefWindowName(ps, "(): window = ", cw->wid_client);
+	printfdfWindowName(ps, "(): window = ", cw->wid_client);
 
 	if (unlikely(!cw))
 	{
-		// printfef("(): if (unlikely(!cw))");
+		printfdf(false, "(): if (unlikely(!cw))");
 		return;
 	}
 	assert(cw->mini.window);
@@ -95,7 +107,7 @@ focus_miniw_adv(session_t *ps, ClientWin *cw, bool move_ptr) {
 
 	if (move_ptr)
 	{
-		// printfef("(): if (move_ptr)");
+		printfdf(false, "(): if (move_ptr)");
 		XWarpPointer(ps->dpy, None, cw->mini.window, 0, 0, 0, 0, cw->mini.width / 2, cw->mini.height / 2);
 	}
 	XSetInputFocus(ps->dpy, cw->mini.window, RevertToParent, CurrentTime);
@@ -104,8 +116,8 @@ focus_miniw_adv(session_t *ps, ClientWin *cw, bool move_ptr) {
 	ps->mainwin->client_to_focus = cw;
 	ps->mainwin->client_to_focus->focused = 1;
 
-	// printfef("(): ");
-	// printfef("(): client_to_focus = %p", (uintptr_t)ps->mainwin->client_to_focus);
+	printfdf(false, "(): ");
+	printfdf(false, "(): client_to_focus = %p", ps->mainwin->client_to_focus);
 }
 
 static inline void
@@ -120,7 +132,7 @@ static inline void
 focus_miniw_next(session_t *ps, ClientWin *cw) {
 	dlist *e = dlist_find_data(cw->mainwin->focuslist, cw);
 	if (!e) {
-		printfef("(%#010lx): Client window not found in list.", cw->src.window);
+		printfef(false, "(%#010lx): Client window not found in list.", cw->src.window);
 		return;
 	}
 	if (e->next)
@@ -148,7 +160,7 @@ focus_miniw_prev(session_t *ps, ClientWin *cw) {
 		}
 
 	if (!tgt) {
-		printfef("(%#010lx): Client window not found in list.", cw->src.window);
+		printfef(false, "(%#010lx): Client window not found in list.", cw->src.window);
 		return;
 	}
 

--- a/src/focus.h
+++ b/src/focus.h
@@ -132,7 +132,7 @@ static inline void
 focus_miniw_next(session_t *ps, ClientWin *cw) {
 	dlist *e = dlist_find_data(cw->mainwin->focuslist, cw);
 	if (!e) {
-		printfef(false, "(%#010lx): Client window not found in list.", cw->src.window);
+		printfef(false, "() (%#010lx): Client window not found in list.", cw->src.window);
 		return;
 	}
 	if (e->next)
@@ -160,7 +160,7 @@ focus_miniw_prev(session_t *ps, ClientWin *cw) {
 		}
 
 	if (!tgt) {
-		printfef(false, "(%#010lx): Client window not found in list.", cw->src.window);
+		printfef(false, "() (%#010lx): Client window not found in list.", cw->src.window);
 		return;
 	}
 

--- a/src/img-gif.c
+++ b/src/img-gif.c
@@ -39,7 +39,7 @@ sgif_read(session_t *ps, const char *path) {
 #ifdef SGIF_THREADSAFE
 		errstr = GifErrorString(err);
 #endif
-		printfef(false, "(\"%s\"): Failed to open file: %d (%s)", path, err, errstr);
+		printfef(false, "(): (\"%s\"): Failed to open file: %d (%s)", path, err, errstr);
 		goto sgif_read_end;
 	}
 
@@ -51,29 +51,29 @@ sgif_read(session_t *ps, const char *path) {
 			++i;
 			switch (rectype) {
 				case UNDEFINED_RECORD_TYPE:
-					printfef(false, "(\"%s\"): %d: Encountered a record of unknown type.",
+					printfef(false, "(): (\"%s\"): %d: Encountered a record of unknown type.",
 							path, i);
 					break;
 				case SCREEN_DESC_RECORD_TYPE:
-					printfef(false, "(\"%s\"): %d: Encountered a record of "
+					printfef(false, "(): (\"%s\"): %d: Encountered a record of "
 							"ScreenDescRecordType. This shouldn't happen!",
 							path, i);
 					break;
 				case IMAGE_DESC_RECORD_TYPE:
 					if (data) {
-						printfef(false, "(\"%s\"): %d: Extra image section ignored.",
+						printfef(false, "(): (\"%s\"): %d: Extra image section ignored.",
 								path, i);
 						break;
 					}
 					if (GIF_ERROR == DGifGetImageDesc(f)) {
-						printfef(false, "(\"%s\"): %d: Failed to read GIF image info.",
+						printfef(false, "(): (\"%s\"): %d: Failed to read GIF image info.",
 								path, i);
 						break;
 					}
 					width = f->Image.Width;
 					height = f->Image.Height;
 					if (width <= 0 || height <= 0) {
-						printfef(false, "(\"%s\"): %d: Width/height invalid.", path, i);
+						printfef(false, "(): (\"%s\"): %d: Width/height invalid.", path, i);
 						break;
 					}
 					assert(!data);
@@ -81,7 +81,7 @@ sgif_read(session_t *ps, const char *path) {
 					// FIXME: Interlace images may need special treatments
 					for (int j = 0; j < height; ++j)
 						if (GIF_OK != DGifGetLine(f, &data[j * width], width)) {
-							printfef(false, "(\"%s\"): %d: Failed to read line %d.", path, i, j);
+							printfef(false, "(): (\"%s\"): %d: Failed to read line %d.", path, i, j);
 							goto sgif_read_end;
 						}
 					break;
@@ -90,7 +90,7 @@ sgif_read(session_t *ps, const char *path) {
 						int code = 0;
 						GifByteType *pbytes = NULL;
 						if (GIF_OK != DGifGetExtension(f, &code, &pbytes) || !pbytes) {
-							printfef(false, "(\"%s\"): %d: Failed to read extension block.",
+							printfef(false, "(): (\"%s\"): %d: Failed to read extension block.",
 									path, i);
 							break;
 						}
@@ -107,7 +107,7 @@ sgif_read(session_t *ps, const char *path) {
 			}
 		}
 		if (unlikely(!data)) {
-			printfef(false, "(\"%s\"): No valid data found.", path);
+			printfef(false, "(): (\"%s\"): No valid data found.", path);
 			goto sgif_read_end;
 		}
 	}
@@ -118,7 +118,7 @@ sgif_read(session_t *ps, const char *path) {
 		ColorMapObject *cmap = f->Image.ColorMap;
 		if (!cmap) cmap = f->SColorMap;
 		if (unlikely(!cmap)) {
-			printfef(false, "(\"%s\"): No colormap found.", path);
+			printfef(false, "(): (\"%s\"): No colormap found.", path);
 			goto sgif_read_end;
 		}
 		tdata = allocchk(malloc(width * height * depth / 8));
@@ -143,7 +143,7 @@ sgif_read(session_t *ps, const char *path) {
 	pictw = simg_data_to_pictw(ps, width, height, depth, tdata, 0);
 	free(tdata);
 	if (unlikely(!pictw)) {
-		printfef(false, "(\"%s\"): Failed to create Picture.", path);
+		printfef(false, "(): (\"%s\"): Failed to create Picture.", path);
 		goto sgif_read_end;
 	}
 

--- a/src/img-gif.c
+++ b/src/img-gif.c
@@ -39,7 +39,7 @@ sgif_read(session_t *ps, const char *path) {
 #ifdef SGIF_THREADSAFE
 		errstr = GifErrorString(err);
 #endif
-		printfef("(\"%s\"): Failed to open file: %d (%s)", path, err, errstr);
+		printfef(false, "(\"%s\"): Failed to open file: %d (%s)", path, err, errstr);
 		goto sgif_read_end;
 	}
 
@@ -51,29 +51,29 @@ sgif_read(session_t *ps, const char *path) {
 			++i;
 			switch (rectype) {
 				case UNDEFINED_RECORD_TYPE:
-					printfef("(\"%s\"): %d: Encountered a record of unknown type.",
+					printfef(false, "(\"%s\"): %d: Encountered a record of unknown type.",
 							path, i);
 					break;
 				case SCREEN_DESC_RECORD_TYPE:
-					printfef("(\"%s\"): %d: Encountered a record of "
+					printfef(false, "(\"%s\"): %d: Encountered a record of "
 							"ScreenDescRecordType. This shouldn't happen!",
 							path, i);
 					break;
 				case IMAGE_DESC_RECORD_TYPE:
 					if (data) {
-						printfef("(\"%s\"): %d: Extra image section ignored.",
+						printfef(false, "(\"%s\"): %d: Extra image section ignored.",
 								path, i);
 						break;
 					}
 					if (GIF_ERROR == DGifGetImageDesc(f)) {
-						printfef("(\"%s\"): %d: Failed to read GIF image info.",
+						printfef(false, "(\"%s\"): %d: Failed to read GIF image info.",
 								path, i);
 						break;
 					}
 					width = f->Image.Width;
 					height = f->Image.Height;
 					if (width <= 0 || height <= 0) {
-						printfef("(\"%s\"): %d: Width/height invalid.", path, i);
+						printfef(false, "(\"%s\"): %d: Width/height invalid.", path, i);
 						break;
 					}
 					assert(!data);
@@ -81,7 +81,7 @@ sgif_read(session_t *ps, const char *path) {
 					// FIXME: Interlace images may need special treatments
 					for (int j = 0; j < height; ++j)
 						if (GIF_OK != DGifGetLine(f, &data[j * width], width)) {
-							printfef("(\"%s\"): %d: Failed to read line %d.", path, i, j);
+							printfef(false, "(\"%s\"): %d: Failed to read line %d.", path, i, j);
 							goto sgif_read_end;
 						}
 					break;
@@ -90,7 +90,7 @@ sgif_read(session_t *ps, const char *path) {
 						int code = 0;
 						GifByteType *pbytes = NULL;
 						if (GIF_OK != DGifGetExtension(f, &code, &pbytes) || !pbytes) {
-							printfef("(\"%s\"): %d: Failed to read extension block.",
+							printfef(false, "(\"%s\"): %d: Failed to read extension block.",
 									path, i);
 							break;
 						}
@@ -107,7 +107,7 @@ sgif_read(session_t *ps, const char *path) {
 			}
 		}
 		if (unlikely(!data)) {
-			printfef("(\"%s\"): No valid data found.", path);
+			printfef(false, "(\"%s\"): No valid data found.", path);
 			goto sgif_read_end;
 		}
 	}
@@ -118,7 +118,7 @@ sgif_read(session_t *ps, const char *path) {
 		ColorMapObject *cmap = f->Image.ColorMap;
 		if (!cmap) cmap = f->SColorMap;
 		if (unlikely(!cmap)) {
-			printfef("(\"%s\"): No colormap found.", path);
+			printfef(false, "(\"%s\"): No colormap found.", path);
 			goto sgif_read_end;
 		}
 		tdata = allocchk(malloc(width * height * depth / 8));
@@ -143,7 +143,7 @@ sgif_read(session_t *ps, const char *path) {
 	pictw = simg_data_to_pictw(ps, width, height, depth, tdata, 0);
 	free(tdata);
 	if (unlikely(!pictw)) {
-		printfef("(\"%s\"): Failed to create Picture.", path);
+		printfef(false, "(\"%s\"): Failed to create Picture.", path);
 		goto sgif_read_end;
 	}
 

--- a/src/img-jpeg.c
+++ b/src/img-jpeg.c
@@ -14,7 +14,7 @@ sjpg_read(session_t *ps, const char *path) {
 
 	FILE *fp = fopen(path, "rb");
 	if (unlikely(!fp)) {
-		printfef("(\"%s\"): Failed to open file.", path);
+		printfef(false, "(\"%s\"): Failed to open file.", path);
 		goto sjpg_read_end;
 	}
 	jpeg_stdio_src(&cinfo, fp);
@@ -35,7 +35,7 @@ sjpg_read(session_t *ps, const char *path) {
 		while (cinfo.output_scanline < cinfo.output_height) {
 			if (unlikely(!jpeg_read_scanlines(&cinfo, &rowptrs[cinfo.output_scanline],
 							cinfo.output_height - cinfo.output_scanline))) {
-				printfef("(\"%s\"): Failed to read scanline %d.", path,
+				printfef(false, "(\"%s\"): Failed to read scanline %d.", path,
 						cinfo.output_scanline);
 				goto sjpg_read_end;
 			}
@@ -60,14 +60,14 @@ sjpg_read(session_t *ps, const char *path) {
 		}
 	}
 	if (unlikely(!jpeg_finish_decompress(&cinfo))) {
-		printfef("(\"%s\"): Failed to finish decompression.", path);
+		printfef(false, "(\"%s\"): Failed to finish decompression.", path);
 		goto sjpg_read_end;
 	}
 	need_abort = false;
 	pictw = simg_data_to_pictw(ps, width, height, depth, data, 0);
 	free(data);
 	if (unlikely(!pictw)) {
-		printfef("(\"%s\"): Failed to create Picture.", path);
+		printfef(false, "(\"%s\"): Failed to create Picture.", path);
 		goto sjpg_read_end;
 	}
 

--- a/src/img-jpeg.c
+++ b/src/img-jpeg.c
@@ -14,7 +14,7 @@ sjpg_read(session_t *ps, const char *path) {
 
 	FILE *fp = fopen(path, "rb");
 	if (unlikely(!fp)) {
-		printfef(false, "(\"%s\"): Failed to open file.", path);
+		printfef(false, "(): (\"%s\"): Failed to open file.", path);
 		goto sjpg_read_end;
 	}
 	jpeg_stdio_src(&cinfo, fp);
@@ -35,7 +35,7 @@ sjpg_read(session_t *ps, const char *path) {
 		while (cinfo.output_scanline < cinfo.output_height) {
 			if (unlikely(!jpeg_read_scanlines(&cinfo, &rowptrs[cinfo.output_scanline],
 							cinfo.output_height - cinfo.output_scanline))) {
-				printfef(false, "(\"%s\"): Failed to read scanline %d.", path,
+				printfef(false, "(): (\"%s\"): Failed to read scanline %d.", path,
 						cinfo.output_scanline);
 				goto sjpg_read_end;
 			}
@@ -60,14 +60,14 @@ sjpg_read(session_t *ps, const char *path) {
 		}
 	}
 	if (unlikely(!jpeg_finish_decompress(&cinfo))) {
-		printfef(false, "(\"%s\"): Failed to finish decompression.", path);
+		printfef(false, "(): (\"%s\"): Failed to finish decompression.", path);
 		goto sjpg_read_end;
 	}
 	need_abort = false;
 	pictw = simg_data_to_pictw(ps, width, height, depth, data, 0);
 	free(data);
 	if (unlikely(!pictw)) {
-		printfef(false, "(\"%s\"): Failed to create Picture.", path);
+		printfef(false, "(): (\"%s\"): Failed to create Picture.", path);
 		goto sjpg_read_end;
 	}
 

--- a/src/img-png.c
+++ b/src/img-png.c
@@ -10,7 +10,7 @@
 
 void
 spng_about(FILE *os) {
-	fprintf(os, "PNG support: Yes\n"
+	printfdf(true, "PNG support: Yes\n"
 			"  Compiled with libpng %s, using %s.\n"
 			"  Compiled with zlib %s, using %s.\n",
 			PNG_LIBPNG_VER_STRING, png_libpng_ver,
@@ -28,16 +28,16 @@ spng_read(session_t *ps, const char *path) {
 	FILE *fp = fopen(path, "rb");
 	bool need_premultiply = false;
 	if (unlikely(!fp)) {
-		printfef("(\"%s\"): Failed to open file.", path);
+		printfef(false, "(\"%s\"): Failed to open file.", path);
 		goto spng_read_end;
 	}
 	if (unlikely(SPNG_SIGBYTES != fread(&sig, 1, SPNG_SIGBYTES, fp))) {
-		printfef("(\"%s\"): Failed to read %d-byte signature.",
+		printfef(false, "(\"%s\"): Failed to read %d-byte signature.",
 				path, SPNG_SIGBYTES);
 		goto spng_read_end;
 	}
 	if (unlikely(png_sig_cmp((png_bytep) sig, 0, SPNG_SIGBYTES))) {
-		printfef("(\"%s\"): PNG signature invalid.", path);
+		printfef(false, "(\"%s\"): PNG signature invalid.", path);
 		goto spng_read_end;
 	}
 	png_ptr = allocchk(png_create_read_struct(PNG_LIBPNG_VER_STRING,
@@ -59,7 +59,7 @@ spng_read(session_t *ps, const char *path) {
 
 		// Scale or strip 16-bit colors
 		if (bit_depth == 16) {
-			printfdf("(\"%s\"): Scaling 16-bit colors.", path);
+			printfdf(false, "(\"%s\"): Scaling 16-bit colors.", path);
 #if PNG_LIBPNG_VER >= 10504
 			png_set_scale_16(png_ptr);
 #else
@@ -76,19 +76,19 @@ spng_read(session_t *ps, const char *path) {
 
 		// Convert palette to RGB
 		if (color_type == PNG_COLOR_TYPE_PALETTE) {
-			printfdf("(\"%s\"): Converting palette PNG to RGB.", path);
+			printfdf(false, "(\"%s\"): Converting palette PNG to RGB.", path);
 			png_set_palette_to_rgb(png_ptr);
 			color_type = PNG_COLOR_TYPE_RGB;
 		}
 
 		if (png_get_valid(png_ptr, info_ptr, PNG_INFO_tRNS)) {
-			printfdf("(\"%s\"): Converting rDNS to full alpha.", path);
+			printfdf(false, "(\"%s\"): Converting rDNS to full alpha.", path);
 			png_set_tRNS_to_alpha(png_ptr);
 		}
 
 		if (color_type == PNG_COLOR_TYPE_GRAY
 				|| PNG_COLOR_TYPE_GRAY_ALPHA == color_type) {
-			printfdf("(\"%s\"): Converting gray (+ alpha) PNG to RGB.", path);
+			printfdf(false, "(\"%s\"): Converting gray (+ alpha) PNG to RGB.", path);
 			png_set_gray_to_rgb(png_ptr);
 			if (PNG_COLOR_TYPE_GRAY == color_type)
 				color_type = PNG_COLOR_TYPE_RGB;
@@ -98,7 +98,7 @@ spng_read(session_t *ps, const char *path) {
 
 		/*
 		if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8) {
-			printfdf("(\"%s\"): Converting 1/2/4 bit gray PNG to 8-bit.", path);
+			printfdf(false, "(\"%s\"): Converting 1/2/4 bit gray PNG to 8-bit.", path);
 #if PNG_LIBPNG_VER >= 10209
 			png_set_expand_gray_1_2_4_to_8(png_ptr);
 #else
@@ -110,7 +110,7 @@ spng_read(session_t *ps, const char *path) {
 
 		// Somehow XImage requires 24-bit visual to use 32 bits per pixel
 		if (color_type == PNG_COLOR_TYPE_RGB) {
-			printfdf("(\"%s\"): Appending filler alpha values.", path);
+			printfdf(false, "(\"%s\"): Appending filler alpha values.", path);
 			png_set_filler(png_ptr, 0xff, PNG_FILLER_AFTER);
 		}
 
@@ -161,7 +161,7 @@ spng_read(session_t *ps, const char *path) {
 				row_pointers[0], rowbytes);
 		png_free(png_ptr, row_pointers[0]);
 		if (unlikely(!pictw)) {
-			printfef("(\"%s\"): Failed to create Picture.", path);
+			printfef(false, "(\"%s\"): Failed to create Picture.", path);
 			goto spng_read_end;
 		}
 	}

--- a/src/img-png.c
+++ b/src/img-png.c
@@ -10,7 +10,7 @@
 
 void
 spng_about(FILE *os) {
-	printfdf(true, "PNG support: Yes\n"
+	printfdf(true, "(): PNG support: Yes\n"
 			"  Compiled with libpng %s, using %s.\n"
 			"  Compiled with zlib %s, using %s.\n",
 			PNG_LIBPNG_VER_STRING, png_libpng_ver,
@@ -28,16 +28,16 @@ spng_read(session_t *ps, const char *path) {
 	FILE *fp = fopen(path, "rb");
 	bool need_premultiply = false;
 	if (unlikely(!fp)) {
-		printfef(false, "(\"%s\"): Failed to open file.", path);
+		printfef(false, "(): (\"%s\"): Failed to open file.", path);
 		goto spng_read_end;
 	}
 	if (unlikely(SPNG_SIGBYTES != fread(&sig, 1, SPNG_SIGBYTES, fp))) {
-		printfef(false, "(\"%s\"): Failed to read %d-byte signature.",
+		printfef(false, "(): (\"%s\"): Failed to read %d-byte signature.",
 				path, SPNG_SIGBYTES);
 		goto spng_read_end;
 	}
 	if (unlikely(png_sig_cmp((png_bytep) sig, 0, SPNG_SIGBYTES))) {
-		printfef(false, "(\"%s\"): PNG signature invalid.", path);
+		printfef(false, "(): (\"%s\"): PNG signature invalid.", path);
 		goto spng_read_end;
 	}
 	png_ptr = allocchk(png_create_read_struct(PNG_LIBPNG_VER_STRING,
@@ -59,7 +59,7 @@ spng_read(session_t *ps, const char *path) {
 
 		// Scale or strip 16-bit colors
 		if (bit_depth == 16) {
-			printfdf(false, "(\"%s\"): Scaling 16-bit colors.", path);
+			printfdf(false, "(): (\"%s\"): Scaling 16-bit colors.", path);
 #if PNG_LIBPNG_VER >= 10504
 			png_set_scale_16(png_ptr);
 #else
@@ -76,19 +76,19 @@ spng_read(session_t *ps, const char *path) {
 
 		// Convert palette to RGB
 		if (color_type == PNG_COLOR_TYPE_PALETTE) {
-			printfdf(false, "(\"%s\"): Converting palette PNG to RGB.", path);
+			printfdf(false, "(): (\"%s\"): Converting palette PNG to RGB.", path);
 			png_set_palette_to_rgb(png_ptr);
 			color_type = PNG_COLOR_TYPE_RGB;
 		}
 
 		if (png_get_valid(png_ptr, info_ptr, PNG_INFO_tRNS)) {
-			printfdf(false, "(\"%s\"): Converting rDNS to full alpha.", path);
+			printfdf(false, "(): (\"%s\"): Converting rDNS to full alpha.", path);
 			png_set_tRNS_to_alpha(png_ptr);
 		}
 
 		if (color_type == PNG_COLOR_TYPE_GRAY
 				|| PNG_COLOR_TYPE_GRAY_ALPHA == color_type) {
-			printfdf(false, "(\"%s\"): Converting gray (+ alpha) PNG to RGB.", path);
+			printfdf(false, "(): (\"%s\"): Converting gray (+ alpha) PNG to RGB.", path);
 			png_set_gray_to_rgb(png_ptr);
 			if (PNG_COLOR_TYPE_GRAY == color_type)
 				color_type = PNG_COLOR_TYPE_RGB;
@@ -98,7 +98,7 @@ spng_read(session_t *ps, const char *path) {
 
 		/*
 		if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8) {
-			printfdf(false, "(\"%s\"): Converting 1/2/4 bit gray PNG to 8-bit.", path);
+			printfdf(false, "(): (\"%s\"): Converting 1/2/4 bit gray PNG to 8-bit.", path);
 #if PNG_LIBPNG_VER >= 10209
 			png_set_expand_gray_1_2_4_to_8(png_ptr);
 #else
@@ -110,7 +110,7 @@ spng_read(session_t *ps, const char *path) {
 
 		// Somehow XImage requires 24-bit visual to use 32 bits per pixel
 		if (color_type == PNG_COLOR_TYPE_RGB) {
-			printfdf(false, "(\"%s\"): Appending filler alpha values.", path);
+			printfdf(false, "(): (\"%s\"): Appending filler alpha values.", path);
 			png_set_filler(png_ptr, 0xff, PNG_FILLER_AFTER);
 		}
 
@@ -161,7 +161,7 @@ spng_read(session_t *ps, const char *path) {
 				row_pointers[0], rowbytes);
 		png_free(png_ptr, row_pointers[0]);
 		if (unlikely(!pictw)) {
-			printfef(false, "(\"%s\"): Failed to create Picture.", path);
+			printfef(false, "(): (\"%s\"): Failed to create Picture.", path);
 			goto spng_read_end;
 		}
 	}

--- a/src/img-xlib.c
+++ b/src/img-xlib.c
@@ -20,19 +20,19 @@ simg_load_icon(session_t *ps, Window wid, int desired_size) {
 			int wanted_bytes = 0;
 			for (const long *p = prop.data32; p < end; p += wanted_bytes) {
 				if (p + 2 >= end) {
-					printfef("(%#010lx): %d trailing byte(s).", wid, (int) (end - p));
+					printfef(false, "(%#010lx): %d trailing byte(s).", wid, (int) (end - p));
 					break;
 				}
 				width = p[0];
 				height = p[1];
 				if (width <= 0 || height <= 0) {
-					printfef("(%#010lx): (offset %d, width %d, height %d) Invalid width/height.",
+					printfef(false, "(%#010lx): (offset %d, width %d, height %d) Invalid width/height.",
 							wid, (int) (p - prop.data32), width, height);
 					break;
 				}
 				wanted_bytes = 2 + width * height;
 				if ((end - p) < wanted_bytes) {
-					printfef("(%#010lx): (offset %d, width %d, height %d) Not enough bytes (%d/%d).",
+					printfef(false, "(%#010lx): (offset %d, width %d, height %d) Not enough bytes (%d/%d).",
 							wid, (int) (p - prop.data32), width, height, (int) (end - p), wanted_bytes);
 					break;
 				}
@@ -62,9 +62,9 @@ simg_load_icon(session_t *ps, Window wid, int desired_size) {
 					free(converted_data);
 			}
 			if (!pictw)
-				printfef("(%#010lx): Failed to create picture.", wid);
+				printfef(false, "(%#010lx): Failed to create picture.", wid);
 			/* if (pictw)
-				printfdf("(%#010lx): (offset %d, width %d, height %d) Loaded.",
+				printfdf(false, "(%#010lx): (offset %d, width %d, height %d) Loaded.",
 						wid, (int) (best_data - prop.data8), pictw->width, pictw->height); */
 		}
 		free_winprop(&prop);
@@ -104,7 +104,7 @@ simg_load_icon_end:
 	if (pictw && !processed) {
 		pictw = simg_postprocess(ps, pictw, PICTPOSP_SCALEK,
 				desired_size, desired_size, ALIGN_MID, ALIGN_MID, NULL);
-		/* printfdf("(%#010lx): (width %d, height %d) Processed.",
+		/* printfdf(false, "(%#010lx): (width %d, height %d) Processed.",
 				wid, pictw->width, pictw->height); */
 	}
 

--- a/src/img-xlib.c
+++ b/src/img-xlib.c
@@ -20,19 +20,19 @@ simg_load_icon(session_t *ps, Window wid, int desired_size) {
 			int wanted_bytes = 0;
 			for (const long *p = prop.data32; p < end; p += wanted_bytes) {
 				if (p + 2 >= end) {
-					printfef(false, "(%#010lx): %d trailing byte(s).", wid, (int) (end - p));
+					printfef(false, "() (%#010lx): %d trailing byte(s).", wid, (int) (end - p));
 					break;
 				}
 				width = p[0];
 				height = p[1];
 				if (width <= 0 || height <= 0) {
-					printfef(false, "(%#010lx): (offset %d, width %d, height %d) Invalid width/height.",
+					printfef(false, "() (%#010lx): (offset %d, width %d, height %d) Invalid width/height.",
 							wid, (int) (p - prop.data32), width, height);
 					break;
 				}
 				wanted_bytes = 2 + width * height;
 				if ((end - p) < wanted_bytes) {
-					printfef(false, "(%#010lx): (offset %d, width %d, height %d) Not enough bytes (%d/%d).",
+					printfef(false, "() (%#010lx): (offset %d, width %d, height %d) Not enough bytes (%d/%d).",
 							wid, (int) (p - prop.data32), width, height, (int) (end - p), wanted_bytes);
 					break;
 				}
@@ -62,9 +62,9 @@ simg_load_icon(session_t *ps, Window wid, int desired_size) {
 					free(converted_data);
 			}
 			if (!pictw)
-				printfef(false, "(%#010lx): Failed to create picture.", wid);
+				printfef(false, "() (%#010lx): Failed to create picture.", wid);
 			/* if (pictw)
-				printfdf(false, "(%#010lx): (offset %d, width %d, height %d) Loaded.",
+				printfdf(false, "() (%#010lx): (offset %d, width %d, height %d) Loaded.",
 						wid, (int) (best_data - prop.data8), pictw->width, pictw->height); */
 		}
 		free_winprop(&prop);
@@ -104,7 +104,7 @@ simg_load_icon_end:
 	if (pictw && !processed) {
 		pictw = simg_postprocess(ps, pictw, PICTPOSP_SCALEK,
 				desired_size, desired_size, ALIGN_MID, ALIGN_MID, NULL);
-		/* printfdf(false, "(%#010lx): (width %d, height %d) Processed.",
+		/* printfdf(false, "() (%#010lx): (width %d, height %d) Processed.",
 				wid, pictw->width, pictw->height); */
 	}
 

--- a/src/img.c
+++ b/src/img.c
@@ -43,8 +43,9 @@ simg_postprocess(session_t *ps, pictw_t *src, enum pict_posp_mode mode,
 
 	if (!src) {
 		if (twidth && theight) {
-			if (!(dest = create_pictw(ps, twidth, theight, depth)))
-				printfef("(): Failed to create Picture.");
+			if (!(dest = create_pictw(ps, twidth, theight, depth))) {
+				printfef(false, "(): Failed to create Picture.");
+			}
 			else
 				XRenderFillRectangle(ps->dpy, PictOpSrc, dest->pict, pc, 0, 0,
 						twidth, theight);
@@ -60,7 +61,7 @@ simg_postprocess(session_t *ps, pictw_t *src, enum pict_posp_mode mode,
 	else if (!theight) theight = (double) twidth / src->width * src->height;
 
 	if (!(dest = create_pictw(ps, twidth, theight, depth))) {
-		printfef("(): Failed to create Picture.");
+		printfef(false, "(): Failed to create Picture.");
 		goto simg_postprocess_end;
 	}
 

--- a/src/img.h
+++ b/src/img.h
@@ -115,7 +115,7 @@ create_pictw_frompixmap(session_t *ps, int width, int height, int depth,
 	pictw_t *pictw = NULL;
 
 	if (!pxmap) {
-		printfef("(%d, %d, %d, %#010lx): Missing pixmap.", width, height, depth, pxmap);
+		printfef(false, "(%d, %d, %d, %#010lx): Missing pixmap.", width, height, depth, pxmap);
 		return NULL;
 	}
 
@@ -126,7 +126,7 @@ create_pictw_frompixmap(session_t *ps, int width, int height, int depth,
 		unsigned rwidth = 0, rheight = 0, rborder_width = 0, rdepth = 0;
 		if (!XGetGeometry(ps->dpy, pxmap,
 				&rroot, &rx, &ry, &rwidth, &rheight, &rborder_width, &rdepth)) {
-			printfef("(%d, %d, %d, %#010lx): Failed to determine pixmap size.", width, height, depth, pxmap);
+			printfef(false, "(%d, %d, %d, %#010lx): Failed to determine pixmap size.", width, height, depth, pxmap);
 			return NULL;
 		}
 		width = rwidth;
@@ -136,14 +136,14 @@ create_pictw_frompixmap(session_t *ps, int width, int height, int depth,
 
 	// Sanity check
 	if (!(width && height && depth)) {
-		printfef("(%d, %d, %d, %#010lx): Failed to get pixmap info.", width, height, depth, pxmap);
+		printfef(false, "(%d, %d, %d, %#010lx): Failed to get pixmap info.", width, height, depth, pxmap);
 		return NULL;
 	}
 
 	// Find X Render format
 	const XRenderPictFormat *rfmt = depth_to_rfmt(ps, depth);
 	if (!rfmt) {
-		printfef("(%d, %d, %d, %#010lx): Failed to find X Render format for depth %d.",
+		printfef(false, "(%d, %d, %d, %#010lx): Failed to find X Render format for depth %d.",
 				width, height, depth, pxmap, depth);
 		return NULL;
 	}
@@ -157,7 +157,7 @@ create_pictw_frompixmap(session_t *ps, int width, int height, int depth,
 
 	if (!(pictw->pict = XRenderCreatePicture(ps->dpy, pictw->pxmap,
 					rfmt, 0, NULL))) {
-		printfef("(%d, %d, %d, %#010lx): Failed to create Picture.",
+		printfef(false, "(%d, %d, %d, %#010lx): Failed to create Picture.",
 				width, height, depth, pxmap);
 		free_pictw(ps, &pictw);
 	}
@@ -172,7 +172,7 @@ static inline pictw_t *
 create_pictw(session_t *ps, int width, int height, int depth) {
 	Pixmap pxmap = XCreatePixmap(ps->dpy, ps->root, width, height, depth);
 	if (!pxmap) {
-		printfef("(%d, %d, %d): Failed to create Pixmap.", width, height, depth);
+		printfef(false, "(%d, %d, %d): Failed to create Pixmap.", width, height, depth);
 		return NULL;
 	}
 
@@ -265,14 +265,14 @@ simg_pixmap_to_pictw(session_t *ps, int width, int height, int depth,
 	pictw_t *pictw = NULL;
 
 	if (!porig) {
-		printfef("(%d, %d, %d, %#010lx, %#010lx): Failed to create picture for pixmap.",
+		printfef(false, "(%d, %d, %d, %#010lx, %#010lx): Failed to create picture for pixmap.",
 				width, height, depth, pxmap, mask);
 		goto simg_pixmap_to_pict_end;
 	}
 
 	if (mask) {
 		if (!(pmask = create_pictw_frompixmap(ps, width, height, depth, mask))) {
-			printfef("(%d, %d, %d, %#010lx, %#010lx): Failed to create picture for mask.",
+			printfef(false, "(%d, %d, %d, %#010lx, %#010lx): Failed to create picture for mask.",
 					width, height, depth, pxmap, mask);
 			goto simg_pixmap_to_pict_end;
 		}
@@ -281,7 +281,7 @@ simg_pixmap_to_pictw(session_t *ps, int width, int height, int depth,
 	}
 
 	if (!(pictw = create_pictw(ps, porig->width, porig->height, (mask ? 32: porig->depth)))) {
-		printfef("(%d, %d, %d, %#010lx, %#010lx): Failed to create target picture.",
+		printfef(false, "(%d, %d, %d, %#010lx, %#010lx): Failed to create target picture.",
 				width, height, depth, pxmap, mask);
 		goto simg_pixmap_to_pict_end;
 	}
@@ -299,7 +299,7 @@ simg_pixmap_to_pictw(session_t *ps, int width, int height, int depth,
 	/*
 	gc = XCreateGC(ps->dpy, pictw->pxmap, 0, 0);
 	if (!gc) {
-		printfef("(%#010lx, %#010lx, %d, %d, %d): Failed to create GC.",
+		printfef(false, "(%#010lx, %#010lx, %d, %d, %d): Failed to create GC.",
 				pxmap, mask, width, height, depth);
 		free_pictw(ps, &pictw);
 		goto simg_data_to_pict_end;
@@ -334,18 +334,18 @@ simg_data_to_pictw(session_t *ps, int width, int height, int depth,
 			depth, ZPixmap, 0, (char *) data, width, height,
 			8, bytes_per_line);
 	if (!img) {
-		printfef("(%d, %d, %d): Failed to create XImage.",
+		printfef(false, "(%d, %d, %d): Failed to create XImage.",
 				width, height, depth);
 		goto simg_data_to_pict_end;
 	}
 	if (!(pictw = create_pictw(ps, width, height, depth))) {
-		printfef("(%d, %d, %d): Failed to create Picture.",
+		printfef(false, "(%d, %d, %d): Failed to create Picture.",
 				width, height, depth);
 		goto simg_data_to_pict_end;
 	}
 	gc = XCreateGC(ps->dpy, pictw->pxmap, 0, 0);
 	if (!gc) {
-		printfef("(%d, %d, %d): Failed to create GC.",
+		printfef(false, "(%d, %d, %d): Failed to create GC.",
 				width, height, depth);
 		free_pictw(ps, &pictw);
 		goto simg_data_to_pict_end;

--- a/src/img.h
+++ b/src/img.h
@@ -115,7 +115,7 @@ create_pictw_frompixmap(session_t *ps, int width, int height, int depth,
 	pictw_t *pictw = NULL;
 
 	if (!pxmap) {
-		printfef(false, "(%d, %d, %d, %#010lx): Missing pixmap.", width, height, depth, pxmap);
+		printfef(false, "(): (%d, %d, %d, %#010lx): Missing pixmap.", width, height, depth, pxmap);
 		return NULL;
 	}
 
@@ -126,7 +126,7 @@ create_pictw_frompixmap(session_t *ps, int width, int height, int depth,
 		unsigned rwidth = 0, rheight = 0, rborder_width = 0, rdepth = 0;
 		if (!XGetGeometry(ps->dpy, pxmap,
 				&rroot, &rx, &ry, &rwidth, &rheight, &rborder_width, &rdepth)) {
-			printfef(false, "(%d, %d, %d, %#010lx): Failed to determine pixmap size.", width, height, depth, pxmap);
+			printfef(false, "(): (%d, %d, %d, %#010lx): Failed to determine pixmap size.", width, height, depth, pxmap);
 			return NULL;
 		}
 		width = rwidth;
@@ -136,14 +136,14 @@ create_pictw_frompixmap(session_t *ps, int width, int height, int depth,
 
 	// Sanity check
 	if (!(width && height && depth)) {
-		printfef(false, "(%d, %d, %d, %#010lx): Failed to get pixmap info.", width, height, depth, pxmap);
+		printfef(false, "(): (%d, %d, %d, %#010lx): Failed to get pixmap info.", width, height, depth, pxmap);
 		return NULL;
 	}
 
 	// Find X Render format
 	const XRenderPictFormat *rfmt = depth_to_rfmt(ps, depth);
 	if (!rfmt) {
-		printfef(false, "(%d, %d, %d, %#010lx): Failed to find X Render format for depth %d.",
+		printfef(false, "(): (%d, %d, %d, %#010lx): Failed to find X Render format for depth %d.",
 				width, height, depth, pxmap, depth);
 		return NULL;
 	}
@@ -157,7 +157,7 @@ create_pictw_frompixmap(session_t *ps, int width, int height, int depth,
 
 	if (!(pictw->pict = XRenderCreatePicture(ps->dpy, pictw->pxmap,
 					rfmt, 0, NULL))) {
-		printfef(false, "(%d, %d, %d, %#010lx): Failed to create Picture.",
+		printfef(false, "(): (%d, %d, %d, %#010lx): Failed to create Picture.",
 				width, height, depth, pxmap);
 		free_pictw(ps, &pictw);
 	}
@@ -172,7 +172,7 @@ static inline pictw_t *
 create_pictw(session_t *ps, int width, int height, int depth) {
 	Pixmap pxmap = XCreatePixmap(ps->dpy, ps->root, width, height, depth);
 	if (!pxmap) {
-		printfef(false, "(%d, %d, %d): Failed to create Pixmap.", width, height, depth);
+		printfef(false, "(): (%d, %d, %d): Failed to create Pixmap.", width, height, depth);
 		return NULL;
 	}
 
@@ -265,14 +265,14 @@ simg_pixmap_to_pictw(session_t *ps, int width, int height, int depth,
 	pictw_t *pictw = NULL;
 
 	if (!porig) {
-		printfef(false, "(%d, %d, %d, %#010lx, %#010lx): Failed to create picture for pixmap.",
+		printfef(false, "(): (%d, %d, %d, %#010lx, %#010lx): Failed to create picture for pixmap.",
 				width, height, depth, pxmap, mask);
 		goto simg_pixmap_to_pict_end;
 	}
 
 	if (mask) {
 		if (!(pmask = create_pictw_frompixmap(ps, width, height, depth, mask))) {
-			printfef(false, "(%d, %d, %d, %#010lx, %#010lx): Failed to create picture for mask.",
+			printfef(false, "(): (%d, %d, %d, %#010lx, %#010lx): Failed to create picture for mask.",
 					width, height, depth, pxmap, mask);
 			goto simg_pixmap_to_pict_end;
 		}
@@ -281,7 +281,7 @@ simg_pixmap_to_pictw(session_t *ps, int width, int height, int depth,
 	}
 
 	if (!(pictw = create_pictw(ps, porig->width, porig->height, (mask ? 32: porig->depth)))) {
-		printfef(false, "(%d, %d, %d, %#010lx, %#010lx): Failed to create target picture.",
+		printfef(false, "(): (%d, %d, %d, %#010lx, %#010lx): Failed to create target picture.",
 				width, height, depth, pxmap, mask);
 		goto simg_pixmap_to_pict_end;
 	}
@@ -299,7 +299,7 @@ simg_pixmap_to_pictw(session_t *ps, int width, int height, int depth,
 	/*
 	gc = XCreateGC(ps->dpy, pictw->pxmap, 0, 0);
 	if (!gc) {
-		printfef(false, "(%#010lx, %#010lx, %d, %d, %d): Failed to create GC.",
+		printfef(false, "(): (%#010lx, %#010lx, %d, %d, %d): Failed to create GC.",
 				pxmap, mask, width, height, depth);
 		free_pictw(ps, &pictw);
 		goto simg_data_to_pict_end;
@@ -334,18 +334,18 @@ simg_data_to_pictw(session_t *ps, int width, int height, int depth,
 			depth, ZPixmap, 0, (char *) data, width, height,
 			8, bytes_per_line);
 	if (!img) {
-		printfef(false, "(%d, %d, %d): Failed to create XImage.",
+		printfef(false, "(): (%d, %d, %d): Failed to create XImage.",
 				width, height, depth);
 		goto simg_data_to_pict_end;
 	}
 	if (!(pictw = create_pictw(ps, width, height, depth))) {
-		printfef(false, "(%d, %d, %d): Failed to create Picture.",
+		printfef(false, "(): (%d, %d, %d): Failed to create Picture.",
 				width, height, depth);
 		goto simg_data_to_pict_end;
 	}
 	gc = XCreateGC(ps->dpy, pictw->pxmap, 0, 0);
 	if (!gc) {
-		printfef(false, "(%d, %d, %d): Failed to create GC.",
+		printfef(false, "(): (%d, %d, %d): Failed to create GC.",
 				width, height, depth);
 		free_pictw(ps, &pictw);
 		goto simg_data_to_pict_end;

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -223,7 +223,7 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 
 	if(! XParseColor(ps->dpy, mw->colormap, ps->o.highlight_tint, &exact_color))
 	{
-		printfef(true, "Couldn't look up color '%s', reverting to #101020", ps->o.highlight_tint);
+		printfef(true, "(): Couldn't look up color '%s', reverting to #101020", ps->o.highlight_tint);
 		mw->highlightTint.red = mw->highlightTint.green = 0x10;
 		mw->highlightTint.blue = 0x20;
 	}
@@ -238,7 +238,7 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	;
 	if(! XParseColor(ps->dpy, mw->colormap, ps->o.shadow_tint, &exact_color))
 	{
-		printfef(true, "Couldn't look up color '%s', reverting to #040404", ps->o.shadow_tint);
+		printfef(true, "(): Couldn't look up color '%s', reverting to #040404", ps->o.shadow_tint);
 		mw->shadowTint.red = mw->shadowTint.green =	mw->shadowTint.blue = 0x04;
 	}
 	else
@@ -358,13 +358,13 @@ mainwin_update(MainWin *mw)
 	}
 	
 # ifdef DEBUG
-	printfdf(false, "--> querying pointer... ");
+	printfdf(false, "(): --> querying pointer... ");
 # endif /* DEBUG */
 	XQueryPointer(ps->dpy, ps->root, &dummy_w, &dummy_w, &root_x, &root_y, &dummy_i, &dummy_i, &dummy_u);
 # ifdef DEBUG	
-	printfdf(false, "+%i+%i\n", root_x, root_y);
+	printfdf(false, "(): +%i+%i\n", root_x, root_y);
 	
-	printfdf(false, "--> figuring out which screen we're on... ");
+	printfdf(false, "(): --> figuring out which screen we're on... ");
 # endif /* DEBUG */
 	iter = mw->xin_info;
 	for(i = 0; i < mw->xin_screens; ++i)
@@ -373,7 +373,7 @@ mainwin_update(MainWin *mw)
 		   root_y >= iter->y_org && root_y < iter->y_org + iter->height)
 		{
 # ifdef DEBUG
-			printfdf(false, "screen %i %ix%i+%i+%i\n", iter->screen_number, iter->width, iter->height, iter->x_org, iter->y_org);
+			printfdf(false, "(): screen %i %ix%i+%i+%i\n", iter->screen_number, iter->width, iter->height, iter->x_org, iter->y_org);
 # endif /* DEBUG */
 			break;
 		}
@@ -382,7 +382,7 @@ mainwin_update(MainWin *mw)
 	if(i == mw->xin_screens)
 	{
 # ifdef DEBUG 
-		printfdf(false, "unknown\n");
+		printfdf(false, "(): unknown\n");
 # endif /* DEBUG */
 		return;
 	}

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -105,7 +105,7 @@ mainwin_create(session_t *ps) {
 	if (ps->xinfo.xinerama_exist && XineramaIsActive(dpy)) {
 		mw->xin_info = XineramaQueryScreens(ps->dpy, &mw->xin_screens);
 # ifdef DEBUG_XINERAMA
-		printfef("(): Xinerama is enabled (%d screens).", mw->xin_screens);
+		printfdf(false, "(): Xinerama is enabled (%d screens).", mw->xin_screens);
 # endif /* DEBUG_XINERAMA */
 	}
 #endif /* CFG_XINERAMA */
@@ -195,7 +195,7 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 		mw->depth  = 32;
 		mw->visual = ps->argb_visual;
 		if (!mw->visual) {
-			printfef("(): Couldn't find ARGB visual, lazy transparency can't work.");
+			printfef(true, "(): Couldn't find ARGB visual, lazy transparency can't work.");
 			goto mainwin_create_err;
 		}
 	}
@@ -210,7 +210,7 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	XColor exact_color;
 
 	if(!XParseColor(ps->dpy, mw->colormap, ps->o.normal_tint, &exact_color)) {
-		printfef("(): Couldn't look up color '%s', reverting to black.", ps->o.normal_tint);
+		printfef(true, "(): Couldn't look up color '%s', reverting to black.", ps->o.normal_tint);
 		mw->normalTint.red = mw->normalTint.green = mw->normalTint.blue = 0;
 	}
 	else
@@ -223,7 +223,7 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 
 	if(! XParseColor(ps->dpy, mw->colormap, ps->o.highlight_tint, &exact_color))
 	{
-		fprintf(stderr, "Couldn't look up color '%s', reverting to #101020", ps->o.highlight_tint);
+		printfef(true, "Couldn't look up color '%s', reverting to #101020", ps->o.highlight_tint);
 		mw->highlightTint.red = mw->highlightTint.green = 0x10;
 		mw->highlightTint.blue = 0x20;
 	}
@@ -238,7 +238,7 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	;
 	if(! XParseColor(ps->dpy, mw->colormap, ps->o.shadow_tint, &exact_color))
 	{
-		fprintf(stderr, "Couldn't look up color '%s', reverting to #040404", ps->o.shadow_tint);
+		printfef(true, "Couldn't look up color '%s', reverting to #040404", ps->o.shadow_tint);
 		mw->shadowTint.red = mw->shadowTint.green =	mw->shadowTint.blue = 0x04;
 	}
 	else
@@ -358,13 +358,13 @@ mainwin_update(MainWin *mw)
 	}
 	
 # ifdef DEBUG
-	fprintf(stderr, "--> querying pointer... ");
+	printfdf(false, "--> querying pointer... ");
 # endif /* DEBUG */
 	XQueryPointer(ps->dpy, ps->root, &dummy_w, &dummy_w, &root_x, &root_y, &dummy_i, &dummy_i, &dummy_u);
 # ifdef DEBUG	
-	fprintf(stderr, "+%i+%i\n", root_x, root_y);
+	printfdf(false, "+%i+%i\n", root_x, root_y);
 	
-	fprintf(stderr, "--> figuring out which screen we're on... ");
+	printfdf(false, "--> figuring out which screen we're on... ");
 # endif /* DEBUG */
 	iter = mw->xin_info;
 	for(i = 0; i < mw->xin_screens; ++i)
@@ -373,7 +373,7 @@ mainwin_update(MainWin *mw)
 		   root_y >= iter->y_org && root_y < iter->y_org + iter->height)
 		{
 # ifdef DEBUG
-			fprintf(stderr, "screen %i %ix%i+%i+%i\n", iter->screen_number, iter->width, iter->height, iter->x_org, iter->y_org);
+			printfdf(false, "screen %i %ix%i+%i+%i\n", iter->screen_number, iter->width, iter->height, iter->x_org, iter->y_org);
 # endif /* DEBUG */
 			break;
 		}
@@ -382,7 +382,7 @@ mainwin_update(MainWin *mw)
 	if(i == mw->xin_screens)
 	{
 # ifdef DEBUG 
-		fprintf(stderr, "unknown\n");
+		printfdf(false, "unknown\n");
 # endif /* DEBUG */
 		return;
 	}
@@ -413,7 +413,7 @@ mainwin_map(MainWin *mw) {
 		int ret = XGrabKeyboard(ps->dpy, mw->window, True, GrabModeAsync,
 				GrabModeAsync, CurrentTime);
 		if (Success != ret)
-			printfef("(): Failed to grab keyboard (%d), troubles ahead.", ret);
+			printfef(true, "(): Failed to grab keyboard (%d), troubles ahead.", ret);
 	} */
 	mw->mapped = true;
 }
@@ -513,7 +513,7 @@ mainwin_transform(MainWin *mw, float f)
 
 int
 mainwin_handle(MainWin *mw, XEvent *ev) {
-	// printfef("(): ");
+	printfdf(false, "(): ");
 	session_t *ps = mw->ps;
 
 	switch(ev->type) {
@@ -522,17 +522,17 @@ mainwin_handle(MainWin *mw, XEvent *ev) {
 			break;
 		case KeyPress:
 		case KeyRelease:
-			// printfef("(): KeyPress or KeyRelease");
+			printfdf(false, "(): KeyPress or KeyRelease");
 			// if(mw->client_to_focus)
 			// {
-				// printfef("(): clientwin_handle(mw->client_to_focus, ev);");
+				// printfdf(false, "(): clientwin_handle(mw->client_to_focus, ev);");
 			if(clientwin_handle(mw->client_to_focus, ev))
 				return 1;
 
 			// }
 			// else
 			// {
-			// 	printfef("(): mw->client_to_focus == NULL");				
+			// 	printfdf(false, "(): mw->client_to_focus == NULL");				
 			// }
 			break;
 		case ButtonPress:
@@ -540,12 +540,12 @@ mainwin_handle(MainWin *mw, XEvent *ev) {
 			break;
 		case ButtonRelease:
 			if (mw->pressed_mouse) {
-				printfef("(): Detected mouse button release on main window, "
+				printfdf(false, "(): Detected mouse button release on main window, "
 						"exiting.");
 				return 1;
 			}
 			else
-				printfef("(): ButtonRelease %u ignored.", ev->xbutton.button);
+				printfdf(false, "(): ButtonRelease %u ignored.", ev->xbutton.button);
 			break;
 	}
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -26,7 +26,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-bool debuglog = true;
+bool debuglog = false;
 
 enum pipe_cmd_t {
 	// Not ordered properly for backward compatibility
@@ -1402,6 +1402,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 					break;
 				case 'S':
 					debuglog = true;
+					break;
 				// case 't':
 				// 	developer_tests();
 				// 	exit('t' == o ? RET_SUCCESS: RET_BADARG);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -26,6 +26,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+bool debuglog = true;
+
 enum pipe_cmd_t {
 	// Not ordered properly for backward compatibility
 	PIPECMD_RELOAD_CONFIG = 0,
@@ -61,7 +63,7 @@ parse_cliop(session_t *ps, const char *str, enum cliop *dest) {
 			return true;
 		}
 
-	printfef("(\"%s\"): Unrecognized operation.", str);
+	printfef(true, "(\"%s\"): Unrecognized operation.", str);
 	return false;
 }
 
@@ -81,7 +83,7 @@ parse_align(session_t *ps, const char *str, enum align *dest) {
 			return strlen(STRS_ALIGN[i]);
 		}
 
-	printfef("(\"%s\"): Unrecognized operation.", str);
+	printfef(true, "(\"%s\"): Unrecognized operation.", str);
 	return 0;
 }
 
@@ -111,7 +113,7 @@ parse_pict_posp_mode(session_t *ps, const char *str, enum pict_posp_mode *dest) 
 			return strlen(STRS_PICTPOSP[i]);
 		}
 
-	printfef("(\"%s\"): Unrecognized operation.", str);
+	printfef(true, "(\"%s\"): Unrecognized operation.", str);
 	return 0;
 }
 static inline int
@@ -159,7 +161,7 @@ parse_color(session_t *ps, const char *s, XRenderColor *pc) {
 		if (!((next = parse_color_sub(s, &pc->red))
 					&& (next = parse_color_sub((s += next), &pc->green))
 					&& (next = parse_color_sub((s += next), &pc->blue)))) {
-			printfef("(\"%s\"): Failed to read color segment.", s);
+			printfef(true, "(\"%s\"): Failed to read color segment.", s);
 			return 0;
 		}
 		if (!(next = parse_color_sub((s += next), &pc->alpha)))
@@ -168,7 +170,7 @@ parse_color(session_t *ps, const char *s, XRenderColor *pc) {
 		return s - sorig;
 	}
 
-	printfef("(\"%s\"): Unrecognized color format.", s);
+	printfef(true, "(\"%s\"): Unrecognized color format.", s);
 	return 0;
 }
 
@@ -204,7 +206,7 @@ parse_size(const char *s, int *px, int *py) {
 		if (endptr && s != endptr) {
 			*py = val;
 			if (*py < 0) {
-				printfef("(\"%s\"): Invalid height.", s);
+				printfef(true, "(\"%s\"): Invalid height.", s);
 				return 0;
 			}
 			s = endptr;
@@ -218,7 +220,7 @@ parse_size(const char *s, int *px, int *py) {
 		return 0;
 
 	if (!isspace0(*s)) {
-		printfef("(\"%s\"): Trailing characters.", s);
+		printfef(true, "(\"%s\"): Trailing characters.", s);
 		return 0;
 	}
 
@@ -331,10 +333,9 @@ daemon_count_clients(MainWin *mw, Bool *touched, Window leader)
 	// while mw->clientondesktop is only those in current virtual desktop
 	// if that option is user supplied
 
-	// printfef("(): updating dl list of clients");
 	update_clients(mw, 0);
 	if (!mw->clients) {
-		printfef("(): No client windows found.");
+		printfdf(false, "(): No client windows found.");
 		return;
 	}
 
@@ -348,7 +349,7 @@ daemon_count_clients(MainWin *mw, Bool *touched, Window leader)
 		dlist *tmp = dlist_first(dlist_find_all(mw->clients,
 					(dlist_match_func) clientwin_validate_func, &desktop));
 		if (!tmp) {
-			printfef("(): No client window on current desktop found.");
+			printfdf(false, "(): No client window on current desktop found.");
 			return;
 		}
 
@@ -531,7 +532,7 @@ ev_window(session_t *ps, const XEvent *ev) {
 	if (ps->xinfo.damage_ev_base + XDamageNotify == ev->type)
 	  return ((XDamageNotifyEvent *) ev)->drawable;
 
-	printf("(): Failed to find window for event type %d. Troubles ahead.",
+	printfef(false, "(): Failed to find window for event type %d. Troubles ahead.",
 			ev->type);
 
 	return ev->xany.window;
@@ -550,7 +551,7 @@ ev_dump(session_t *ps, const MainWin *mw, const XEvent *ev) {
 	if (mw && mw->window == wid) wextra = "(Main)";
 
 	print_timestamp(ps);
-	printfd("Event %-13.13s wid %#010lx %s", name, wid, wextra);
+	printfdf(false, "Event %-13.13s wid %#010lx %s", name, wid, wextra);
 }
 
 static void
@@ -638,7 +639,7 @@ skippy_activate(MainWin *mw, Window leader, bool paging)
 	if (paging) {
 		init_desktop_layout(mw, mw->revert_focus_win, leader);
 		if (!mw->clientondesktop) {
-			printfef("(): Failed to build layout.");
+			printfef(false, "(): Failed to build layout.");
 			return false;
 		}
 		mw->focuslist = mw->clientondesktop;
@@ -646,7 +647,7 @@ skippy_activate(MainWin *mw, Window leader, bool paging)
 	else {
 		init_layout(mw, mw->revert_focus_win, leader);
 		if (!mw->clientondesktop) {
-			printfef("(): Failed to build layout.");
+			printfef(false, "(): Failed to build layout.");
 			return false;
 		}
 	}
@@ -681,7 +682,7 @@ open_pipe(session_t *ps, struct pollfd *r_fd) {
 		return true;
 	}
 	else {
-		printfef("(): Failed to open pipe \"%s\": %d", ps->o.pipePath, errno);
+		printfef(true, "(): Failed to open pipe \"%s\": %d", ps->o.pipePath, errno);
 		perror("open");
 	}
 
@@ -718,14 +719,10 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 		// Activation goes first, so that it won't be delayed by poll()
 		if (!mw && activate) {
-            // printfef("(): if (!mw && activate) {");
-
 			assert(ps->mainwin);
 			activate = false;
 
 			if (skippy_activate(ps->mainwin, None, paging)) {
-                // printfef("(): if (skippy_activate(ps->mainwin, None)) {");
-                // printfef("(): was in skippy_activate");
 				last_rendered = time_in_millis();
 				mw = ps->mainwin;
 				refocus = false;
@@ -758,8 +755,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 			mw->clientondesktop = 0;
 
 			if (refocus && mw->revert_focus_win) {
-				// printfef("(): if (refocus && mw->revert_focus_win) {");
-				// printfef("(): wm_activate_window(ps, mw->revert_focus_win);");
 				// No idea why. Plain XSetInputFocus() no longer works after ungrabbing.
 				wm_activate_window(ps, mw->revert_focus_win);
 				refocus = false;
@@ -829,7 +824,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 				ev_dump(ps, mw, &ev);
 #endif
 				Window wid = ev_window(ps, &ev);
-//printfdf("(): Event!);
 
 				if (mw && MotionNotify == ev.type)
 				{
@@ -868,17 +862,17 @@ mainloop(session_t *ps, bool activate_on_start) {
 								ev.xmotion.x_root, ev.xmotion.y_root);
 				}
 				else if (mw && ev.type == DestroyNotify) {
-					// printfef("(): else if (ev.type == DestroyNotify) {");
+					printfdf(false, "(): else if (ev.type == DestroyNotify) {");
 					daemon_count_clients(ps->mainwin, 0, None);
 					if (!mw->clientondesktop) {
-						printfef("(): Last client window destroyed/unmapped, "
+						printfdf(false, "(): Last client window destroyed/unmapped, "
 								"exiting.");
 						die = true;
 						mw->client_to_focus = NULL;
 					}
 				}
 				else if (ev.type == MapNotify || ev.type == UnmapNotify) {
-					// printfef("(): else if (ev.type == MapNotify || ev.type == UnmapNotify) {");
+					printfdf(false, "(): else if (ev.type == MapNotify || ev.type == UnmapNotify) {");
 					daemon_count_clients(ps->mainwin, 0, None);
 					dlist *iter = (wid ? dlist_find(ps->mainwin->clients, clientwin_cmp_func, (void *) wid): NULL);
 					if (iter) {
@@ -888,8 +882,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 					}
 				}
 				else if (mw && (ps->xinfo.damage_ev_base + XDamageNotify == ev.type)) {
-					//printfef("(): else if (ev.type == XDamageNotify) {");
-					// XDamageNotifyEvent *d_ev = (XDamageNotifyEvent *) &ev;
+					//printfdf(false, "(): else if (ev.type == XDamageNotify) {");
 					dlist *iter = dlist_find(ps->mainwin->clients, clientwin_cmp_func,
 							(void *) wid);
 					pending_damage = true;
@@ -900,17 +893,11 @@ mainloop(session_t *ps, bool activate_on_start) {
 				else if (mw && wid == mw->window)
 					die = mainwin_handle(mw, &ev);
 				else if (mw && PropertyNotify == ev.type) {
-					printfef("(): else if (ev.type == PropertyNotify) {");
-
-					// printfef("(): else if (PropertyNotify == ev.type) {");
+					printfdf(false, "(): else if (ev.type == PropertyNotify) {");
 
 					if (!ps->o.background &&
 							(ESETROOT_PMAP_ID == ev.xproperty.atom
 							 || _XROOTPMAP_ID == ev.xproperty.atom)) {
-
-					    // printfef("(): if (!ps->o.background && ...");
-					    // printfef("(): mainwin_update_background(mw);");
-					    // printfef("(): REDUCE(clientwin_render((ClientWin *)iter->data), mw->clientondesktop);");
 
 						mainwin_update_background(mw);
 						REDUCE(clientwin_render((ClientWin *)iter->data), mw->clientondesktop);
@@ -924,8 +911,6 @@ mainloop(session_t *ps, bool activate_on_start) {
 						if (cw->mini.window == wid) {
                             if (!(POLLIN & r_fd[1].revents))
                             {
-							    // we handle key events in here
-                                // printfef("(): die = clientwin_handle(cw, &ev);");
 							    die = clientwin_handle(cw, &ev);
                             }
 							break;
@@ -936,14 +921,12 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 			// Do delayed painting if it's active
 			if (mw && pending_damage && !die) {
-				//printfdf("(): delayed painting");
+				//printfdf(false, "(): delayed painting");
 				pending_damage = false;
 				foreach_dlist(mw->clientondesktop) {
 					if (((ClientWin *) iter->data)->damaged)
 					{
-						// printfef("(): if (((ClientWin *) iter->data)->damaged)");
 						clientwin_repair(iter->data);
-						// fputs("\n", stdout);
 					}
 				}
 				last_rendered = time_in_millis();
@@ -962,16 +945,16 @@ mainloop(session_t *ps, bool activate_on_start) {
 			unsigned char piped_input = 0;
 			int read_ret = read(ps->fd_pipe, &piped_input, 1);
 			if (0 == read_ret) {
-				printfdf("(): EOF reached on pipe \"%s\".", ps->o.pipePath);
+				printfdf(false, "(): EOF reached on pipe \"%s\".", ps->o.pipePath);
 				open_pipe(ps, r_fd);
 			}
 			else if (-1 == read_ret) {
 				if (EAGAIN != errno)
-					printfef("(): Reading pipe \"%s\" failed: %d", ps->o.pipePath, errno);
+					printfdf(false, "(): Reading pipe \"%s\" failed: %d", ps->o.pipePath, errno);
 			}
 			else {
 				assert(1 == read_ret);
-				printfdf("(): Received pipe command: %d", piped_input);
+				printfdf(false, "(): Received pipe command: %d", piped_input);
 
 				switch (piped_input) {
 					case PIPECMD_RELOAD_CONFIG:
@@ -982,10 +965,10 @@ mainloop(session_t *ps, bool activate_on_start) {
 					case PIPECMD_ACTIVATE_PAGING:
 						paging = piped_input == PIPECMD_ACTIVATE_PAGING;
 						ps->o.mode = paging? PROGMODE_ACTV_PAGING: PROGMODE_ACTV_EXPOSE;
-						printfef("(): case PIPECMD_ACTIVATE, paging=%d:", paging);
+						printfdf(false, "(): case PIPECMD_ACTIVATE, paging=%d:", paging);
 						if (ps->mainwin->mapped)
 						{
-							printfef("(): if (ps->mainwin->mapped)");
+							printfdf(false, "(): if (ps->mainwin->mapped)");
 							fflush(stdout);fflush(stderr);
 
 							// There is a glitch whereby calling focus_miniw_prev() or focus_miniw_next()
@@ -998,20 +981,20 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 							if (ps->o.focus_initial == FI_PREV)
 							{
-								printfef("(): focus_miniw_prev(ps, mw->client_to_focus);");
+								printfdf(false, "(): focus_miniw_prev(ps, mw->client_to_focus);");
 								focus_miniw_prev(ps, mw->client_to_focus);
 							}
 
 							else if (ps->o.focus_initial == FI_NEXT)
 							{
-								printfef("(): focus_miniw_next(ps, mw->client_to_focus);");
+								printfdf(false, "(): focus_miniw_next(ps, mw->client_to_focus);");
 								focus_miniw_next(ps, mw->client_to_focus);
 							}
 							clientwin_render(mw->client_to_focus);
 						}
 						else
 						{
-							printfef("(): activate = true;");
+							printfdf(false, "(): activate = true;");
 							animating = activate = true;
 						}
 						break;
@@ -1030,7 +1013,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 						}
 						break;
 					case PIPECMD_EXIT_DAEMON:
-						printfdf("(): Exit command received, killing daemon...");
+						printfdf(false, "(): Exit command received, killing daemon...");
 						unlink(ps->o.pipePath);
 						return;
 					case PIPECMD_QUEUE_FI_PREV:
@@ -1040,14 +1023,14 @@ mainloop(session_t *ps, bool activate_on_start) {
 						ps->o.focus_initial = FI_NEXT;
 						break;
 					default:
-						printfdf("(): Unknown daemon command \"%d\" received.", piped_input);
+						printfdf(false, "(): Unknown daemon command \"%d\" received.", piped_input);
 						break;
 				}
 			}
 		}
 
 		if (POLLHUP & r_fd[1].revents) {
-			printfdf("(): PIPEHUP on pipe \"%s\".", ps->o.pipePath);
+			printfdf(false, "(): PIPEHUP on pipe \"%s\".", ps->o.pipePath);
 			open_pipe(ps, r_fd);
 		}
 	}
@@ -1058,7 +1041,7 @@ send_command_to_daemon_via_fifo(int command, const char *pipePath) {
 	{
 		int access_ret = 0;
 		if ((access_ret = access(pipePath, W_OK))) {
-			printfef("(): Failed to access() pipe \"%s\": %d", pipePath, access_ret);
+			printfef(true, "(): Failed to access() pipe \"%s\": %d", pipePath, access_ret);
 			perror("access");
 			exit(1);
 		}
@@ -1066,7 +1049,7 @@ send_command_to_daemon_via_fifo(int command, const char *pipePath) {
 
 	FILE *fp = fopen(pipePath, "w");
 
-	printfdf("(): Sending command...");
+	printfdf(false, "(): Sending command...");
 	fputc(command, fp);
 
 	fclose(fp);
@@ -1076,55 +1059,55 @@ send_command_to_daemon_via_fifo(int command, const char *pipePath) {
 
 static inline bool
 queue_reload_config(const char *pipePath) {
-	printfdf("(): Reload config file...");
+	printfdf(false, "(): Reload config file...");
 	return send_command_to_daemon_via_fifo(PIPECMD_RELOAD_CONFIG, pipePath);
 }
 
 static inline bool
 queue_initial_focus_prev(const char *pipePath) {
-	printfdf("(): Set initial focus to previous selection...");
+	printfdf(false, "(): Set initial focus to previous selection...");
 	return send_command_to_daemon_via_fifo(PIPECMD_QUEUE_FI_PREV, pipePath);
 }
 
 static inline bool
 queue_initial_focus_next(const char *pipePath) {
-	printfdf("(): Set initial focus to next selection...");
+	printfdf(false, "(): Set initial focus to next selection...");
 	return send_command_to_daemon_via_fifo(PIPECMD_QUEUE_FI_NEXT, pipePath);
 }
 
 static inline bool
 activate_expose(const char *pipePath) {
-	printfdf("(): Activating expose...");
+	printfdf(false, "(): Activating expose...");
 	return send_command_to_daemon_via_fifo(PIPECMD_ACTIVATE_EXPOSE, pipePath);
 }
 
 static inline bool
 activate_paging(const char *pipePath) {
-	printfdf("(): Activating paging...");
+	printfdf(false, "(): Activating paging...");
 	return send_command_to_daemon_via_fifo(PIPECMD_ACTIVATE_PAGING, pipePath);
 }
 
 static inline bool
 exit_daemon(const char *pipePath) {
-	printfdf("(): Killing daemon...");
+	printfdf(false, "(): Killing daemon...");
 	return send_command_to_daemon_via_fifo(PIPECMD_EXIT_DAEMON, pipePath);
 }
 
 static inline bool
 deactivate(const char *pipePath) {
-	printfdf("(): Deactivating...");
+	printfdf(false, "(): Deactivating...");
 	return send_command_to_daemon_via_fifo(PIPECMD_DEACTIVATE, pipePath);
 }
 
 static inline bool
 toggle_expose(const char *pipePath) {
-	printfdf("(): Toggling expose...");
+	printfdf(false, "(): Toggling expose...");
 	return send_command_to_daemon_via_fifo(PIPECMD_TOGGLE_EXPOSE, pipePath);
 }
 
 static inline bool
 toggle_paging(const char *pipePath) {
-	printfdf("(): Toggling paging...");
+	printfdf(false, "(): Toggling paging...");
 	return send_command_to_daemon_via_fifo(PIPECMD_TOGGLE_PAGING, pipePath);
 }
 
@@ -1185,7 +1168,7 @@ xerror(Display *dpy, XErrorEvent *ev) {
 	{
 		char buf[BUF_LEN] = "";
 		XGetErrorText(ps->dpy, ev->error_code, buf, BUF_LEN);
-		printfef("error %d (%s) request %d minor %d serial %lu (\"%s\")\n",
+		printfef(false, "error %d (%s) request %d minor %d serial %lu (\"%s\")",
 				ev->error_code, name, ev->request_code,
 				ev->minor_code, ev->serial, buf);
 	}
@@ -1217,7 +1200,7 @@ show_help() {
 			// "  --test                      - Temporary development testing. To be removed.\n"
 			"\n"
 			"  --help              - show this message.\n"
-			"  -S                  - Synchronize X operation (debugging).\n"
+			"  --debug             - enable debugging logs.\n"
 			, stdout);
 #ifdef CFG_LIBPNG
 	spng_about(stdout);
@@ -1256,32 +1239,32 @@ init_xexts(session_t *ps) {
 	ps->xinfo.xinerama_exist = XineramaQueryExtension(dpy,
 			&ps->xinfo.xinerama_ev_base, &ps->xinfo.xinerama_err_base);
 # ifdef DEBUG_XINERAMA
-	printfef("(): Xinerama extension: %s",
+	printfef(true, "(): Xinerama extension: %s",
 			(ps->xinfo.xinerama_exist ? "yes": "no"));
 # endif /* DEBUG_XINERAMA */
 #endif /* CFG_XINERAMA */
 
 	if(!XDamageQueryExtension(dpy,
 				&ps->xinfo.damage_ev_base, &ps->xinfo.damage_err_base)) {
-		printfef("(): FATAL: XDamage extension not found.");
+		printfef(true, "(): FATAL: XDamage extension not found.");
 		return false;
 	}
 
 	if(!XCompositeQueryExtension(dpy, &ps->xinfo.composite_ev_base,
 				&ps->xinfo.composite_err_base)) {
-		printfef("(): FATAL: XComposite extension not found.");
+		printfef(true, "(): FATAL: XComposite extension not found.");
 		return false;
 	}
 
 	if(!XRenderQueryExtension(dpy,
 				&ps->xinfo.render_ev_base, &ps->xinfo.render_err_base)) {
-		printfef("(): FATAL: XRender extension not found.");
+		printfef(true, "(): FATAL: XRender extension not found.");
 		return false;
 	}
 
 	if(!XFixesQueryExtension(dpy,
 				&ps->xinfo.fixes_ev_base, &ps->xinfo.fixes_err_base)) {
-		printfef("(): FATAL: XFixes extension not found.");
+		printfef(true, "(): FATAL: XFixes extension not found.");
 		return false;
 	}
 
@@ -1411,13 +1394,14 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 					break;
 				case OPT_PREV:
 					ps->o.focus_initial = FI_PREV;
-					// fprintf(stdout, "ps->o.focus_initial=%i\n", ps->o.focus_initial);
+					printfdf(false, "ps->o.focus_initial=%i\n", ps->o.focus_initial);
 					break;
 				case OPT_NEXT:
 					ps->o.focus_initial = FI_NEXT;
-					// fprintf(stdout, "ps->o.focus_initial=%i\n", ps->o.focus_initial);
+					printfdf(false, "ps->o.focus_initial=%i\n", ps->o.focus_initial);
 					break;
-				T_CASEBOOL('S', synchronize);
+				case 'S':
+					debuglog = true;
 				// case 't':
 				// 	developer_tests();
 				// 	exit('t' == o ? RET_SUCCESS: RET_BADARG);
@@ -1463,7 +1447,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 			case OPT_NEXT: break;
 #undef T_CASEBOOL
 			default:
-				printfef("(0): Unimplemented option %d.", o);
+				printfef(false, "(0): Unimplemented option %d.", o);
 				exit(RET_UNKNOWN);
 		}
 	}
@@ -1480,7 +1464,7 @@ load_config_file(session_t *ps)
         if (ps->o.config_path)
             config = config_load(ps->o.config_path);
         else
-            printfef("(): WARNING: No configuration file found.");
+            printfef(true, "(): WARNING: No configuration file found.");
         if (!config && user_specified_config)
             return 1;
     }
@@ -1562,6 +1546,8 @@ load_config_file(session_t *ps)
                ps->o.layout = LAYOUT_BOXY;
            }
         }
+		else
+			ps->o.layout = LAYOUT_BOXY;
     }
     config_get_bool_wrap(config, "general", "sortByColumn", &ps->o.sortByColumn);
     config_get_int_wrap(config, "general", "distance", &ps->o.distance, 1, INT_MAX);
@@ -1639,6 +1625,9 @@ load_config_file(session_t *ps)
                 ps->o.background = p;
             free_pictspec(ps, &spec);
         }
+		else {
+			ps->o.background = None;
+		}
     }
     if (!parse_pictspec(ps, config_get(config, "general", "iconFillSpec", "orig mid mid #FFFFFF"), &ps->o.iconFillSpec)
             || !parse_pictspec(ps, config_get(config, "general", "fillSpec", "orig mid mid #FFFFFF"), &ps->o.fillSpec))
@@ -1679,7 +1668,7 @@ int main(int argc, char *argv[]) {
 
 	// Open connection to X
 	if (!(ps->dpy = dpy = XOpenDisplay(NULL))) {
-		printfef("(): FATAL: Couldn't connect to display.");
+		printfef(true, "(): FATAL: Couldn't connect to display.");
 		ret = RET_XFAIL;
 		goto main_end;
 	}
@@ -1687,7 +1676,7 @@ int main(int argc, char *argv[]) {
 		ret = RET_XFAIL;
 		goto main_end;
 	}
-	if (ps->o.synchronize)
+	if (debuglog)
 		XSynchronize(ps->dpy, True);
 	XSetErrorHandler(xerror);
 
@@ -1703,7 +1692,7 @@ int main(int argc, char *argv[]) {
 	// Second pass
 	parse_args(ps, argc, argv, false);
 
-	// fprintf(stdout, "after 2nd pass:  ps->o.focus_initial =  %i\n", ps->o.focus_initial);
+	printfdf(false, "(): after 2nd pass:  ps->o.focus_initial =  %i", ps->o.focus_initial);
 
 	const char* pipePath = ps->o.pipePath;
 
@@ -1765,7 +1754,7 @@ int main(int argc, char *argv[]) {
 	// Main branch
 	MainWin *mw = mainwin_create(ps);
 	if (!mw) {
-		printfef("(): FATAL: Couldn't create main window.");
+		printfef(true, "(): FATAL: Couldn't create main window.");
 		ret = 1;
 		goto main_end;
 	}
@@ -1777,7 +1766,7 @@ int main(int argc, char *argv[]) {
 	if (ps->o.runAsDaemon) {
 		bool flush_file = false;
 
-		printfdf("(): Running as daemon...");
+		printfdf(false, "(): Running as daemon...");
 
 		// Flush file if we could access() it (or, usually, if it exists)
 		if (!access(pipePath, R_OK))
@@ -1786,7 +1775,7 @@ int main(int argc, char *argv[]) {
 		{
 			int result = mkfifo(pipePath, S_IRUSR | S_IWUSR);
 			if (result < 0  && EEXIST != errno) {
-				printfef("(): Failed to create named pipe \"%s\": %d", pipePath, result);
+				printfef(true, "(): Failed to create named pipe \"%s\": %d", pipePath, result);
 				perror("mkfifo");
 				ret = 2;
 				goto main_end;
@@ -1803,7 +1792,7 @@ int main(int argc, char *argv[]) {
 			char *buf[BUF_LEN];
 			while (read(ps->fd_pipe, buf, sizeof(buf)) > 0)
 				continue;
-			printfdf("(): Finished flushing pipe \"%s\".", pipePath);
+			printfdf(false, "(): Finished flushing pipe \"%s\".", pipePath);
 		}
 
 		daemon_count_clients(mw, 0, None);
@@ -1816,7 +1805,7 @@ int main(int argc, char *argv[]) {
 		mainloop(ps, false);
 	}
 	else {
-		printfdf("(): running once then quitting...");
+		printfdf(false, "(): running once then quitting...");
 		mainloop(ps, true);
 	}
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -63,7 +63,7 @@ parse_cliop(session_t *ps, const char *str, enum cliop *dest) {
 			return true;
 		}
 
-	printfef(true, "(\"%s\"): Unrecognized operation.", str);
+	printfef(true, "() (\"%s\"): Unrecognized operation.", str);
 	return false;
 }
 
@@ -83,7 +83,7 @@ parse_align(session_t *ps, const char *str, enum align *dest) {
 			return strlen(STRS_ALIGN[i]);
 		}
 
-	printfef(true, "(\"%s\"): Unrecognized operation.", str);
+	printfef(true, "() (\"%s\"): Unrecognized operation.", str);
 	return 0;
 }
 
@@ -113,7 +113,7 @@ parse_pict_posp_mode(session_t *ps, const char *str, enum pict_posp_mode *dest) 
 			return strlen(STRS_PICTPOSP[i]);
 		}
 
-	printfef(true, "(\"%s\"): Unrecognized operation.", str);
+	printfef(true, "() (\"%s\"): Unrecognized operation.", str);
 	return 0;
 }
 static inline int
@@ -161,7 +161,7 @@ parse_color(session_t *ps, const char *s, XRenderColor *pc) {
 		if (!((next = parse_color_sub(s, &pc->red))
 					&& (next = parse_color_sub((s += next), &pc->green))
 					&& (next = parse_color_sub((s += next), &pc->blue)))) {
-			printfef(true, "(\"%s\"): Failed to read color segment.", s);
+			printfef(true, "() (\"%s\"): Failed to read color segment.", s);
 			return 0;
 		}
 		if (!(next = parse_color_sub((s += next), &pc->alpha)))
@@ -206,7 +206,7 @@ parse_size(const char *s, int *px, int *py) {
 		if (endptr && s != endptr) {
 			*py = val;
 			if (*py < 0) {
-				printfef(true, "(\"%s\"): Invalid height.", s);
+				printfef(true, "() (\"%s\"): Invalid height.", s);
 				return 0;
 			}
 			s = endptr;
@@ -220,7 +220,7 @@ parse_size(const char *s, int *px, int *py) {
 		return 0;
 
 	if (!isspace0(*s)) {
-		printfef(true, "(\"%s\"): Trailing characters.", s);
+		printfef(true, "() (\"%s\"): Trailing characters.", s);
 		return 0;
 	}
 
@@ -551,7 +551,7 @@ ev_dump(session_t *ps, const MainWin *mw, const XEvent *ev) {
 	if (mw && mw->window == wid) wextra = "(Main)";
 
 	print_timestamp(ps);
-	printfdf(false, "Event %-13.13s wid %#010lx %s", name, wid, wextra);
+	printfdf(false, "(): Event %-13.13s wid %#010lx %s", name, wid, wextra);
 }
 
 static void
@@ -1168,7 +1168,7 @@ xerror(Display *dpy, XErrorEvent *ev) {
 	{
 		char buf[BUF_LEN] = "";
 		XGetErrorText(ps->dpy, ev->error_code, buf, BUF_LEN);
-		printfef(false, "error %d (%s) request %d minor %d serial %lu (\"%s\")",
+		printfef(false, "(): error %d (%s) request %d minor %d serial %lu (\"%s\")",
 				ev->error_code, name, ev->request_code,
 				ev->minor_code, ev->serial, buf);
 	}
@@ -1200,7 +1200,7 @@ show_help() {
 			// "  --test                      - Temporary development testing. To be removed.\n"
 			"\n"
 			"  --help              - show this message.\n"
-			"  --debug             - enable debugging logs.\n"
+			"  -S                  - enable debugging logs.\n"
 			, stdout);
 #ifdef CFG_LIBPNG
 	spng_about(stdout);
@@ -1394,11 +1394,11 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 					break;
 				case OPT_PREV:
 					ps->o.focus_initial = FI_PREV;
-					printfdf(false, "ps->o.focus_initial=%i\n", ps->o.focus_initial);
+					printfdf(false, "(): ps->o.focus_initial=%i\n", ps->o.focus_initial);
 					break;
 				case OPT_NEXT:
 					ps->o.focus_initial = FI_NEXT;
-					printfdf(false, "ps->o.focus_initial=%i\n", ps->o.focus_initial);
+					printfdf(false, "(): ps->o.focus_initial=%i\n", ps->o.focus_initial);
 					break;
 				case 'S':
 					debuglog = true;
@@ -1530,26 +1530,29 @@ load_config_file(session_t *ps)
     check_keysyms(ps->o.config_path, ": [bindings] keysReverseDirection =", ps->o.bindings_keysReverseDirection);
     check_modmasks(ps->o.config_path, ": [bindings] modifierKeyMasksReverseDirection =", ps->o.bindings_modifierKeyMasksReverseDirection);
 
-    if (!parse_cliop(ps, config_get(config, "bindings", "miwMouse1", "focus"), &ps->o.bindings_miwMouse[1])
-            || !parse_cliop(ps, config_get(config, "bindings", "miwMouse2", "close-ewmh"), &ps->o.bindings_miwMouse[2])
-            || !parse_cliop(ps, config_get(config, "bindings", "miwMouse3", "iconify"), &ps->o.bindings_miwMouse[3]))
-        return RET_BADARG;
-    {
-        const char *s = config_get(config, "general", "layout", NULL);
-        if (s) {
-           if (strcmp(s,"boxy") == 0) {
-               ps->o.layout = LAYOUT_BOXY;
-           }
-           else if (strcmp(s,"xd") == 0) {
-               ps->o.layout = LAYOUT_XD;
-           }
-           else {
-               ps->o.layout = LAYOUT_BOXY;
-           }
-        }
+	if (!parse_cliop(ps, config_get(config, "bindings", "miwMouse1", "focus"), &ps->o.bindings_miwMouse[1])
+			|| !parse_cliop(ps, config_get(config, "bindings", "miwMouse2", "close-ewmh"), &ps->o.bindings_miwMouse[2])
+			|| !parse_cliop(ps, config_get(config, "bindings", "miwMouse3", "iconify"), &ps->o.bindings_miwMouse[3])) {
+		return RET_BADARG;
+	}
+
+	{
+		const char *s = config_get(config, "general", "layout", NULL);
+		if (s) {
+			if (strcmp(s,"boxy") == 0) {
+				ps->o.layout = LAYOUT_BOXY;
+			}
+			else if (strcmp(s,"xd") == 0) {
+				ps->o.layout = LAYOUT_XD;
+			}
+			else {
+				ps->o.layout = LAYOUT_BOXY;
+			}
+		}
 		else
 			ps->o.layout = LAYOUT_BOXY;
     }
+
     config_get_bool_wrap(config, "general", "sortByColumn", &ps->o.sortByColumn);
     config_get_int_wrap(config, "general", "distance", &ps->o.distance, 1, INT_MAX);
     config_get_bool_wrap(config, "general", "useNetWMFullscreen", &ps->o.useNetWMFullscreen);

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -480,7 +480,7 @@ print_timestamp(session_t *ps) {
 
 	timeval_subtract(&diff, &tm, &ps->time_start);
 
-	printfef(false, "[ %5ld.%02ld ] ", diff.tv_sec, diff.tv_usec / 10000);
+	printfef(false, "() [ %5ld.%02ld ] ", diff.tv_sec, diff.tv_usec / 10000);
 }
 
 /**

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -65,40 +65,7 @@
 
 #define MAX_MOUSE_BUTTONS 4
 
-/**
- * @brief Dump raw bytes in HEX format.
- *
- * @param data pointer to raw data
- * @param len length of data
- */
-static inline void
-hexdump(const char *data, int len) {
-  static const int BYTE_PER_LN = 16;
-
-  if (len <= 0)
-    return;
-
-  // Print header
-  printf("%10s:", "Offset");
-  for (int i = 0; i < BYTE_PER_LN; ++i)
-    printf(" %2d", i);
-  putchar('\n');
-
-  // Dump content
-  for (int offset = 0; offset < len; ++offset) {
-    if (!(offset % BYTE_PER_LN))
-      printf("0x%08x:", offset);
-
-    printf(" %02hhx", data[offset]);
-
-    if ((BYTE_PER_LN - 1) == offset % BYTE_PER_LN)
-      putchar('\n');
-  }
-  if (len % BYTE_PER_LN)
-    putchar('\n');
-
-  fflush(stdout);
-}
+extern bool debuglog;
 
 /// @brief Possible return values.
 
@@ -217,7 +184,6 @@ typedef struct {
 	char *config_path;
 	enum progmode mode;
 	bool runAsDaemon;
-	bool synchronize;
 	int focus_initial;
 
 	int layout;
@@ -292,7 +258,6 @@ typedef struct {
 	.config_path = NULL, \
 	.mode = PROGMODE_NORMAL, \
 	.runAsDaemon = false, \
-	.synchronize = false, \
 \
 	.layout = LAYOUT_XD, \
 	.sortByColumn = true, \
@@ -398,21 +363,13 @@ typedef struct {
 	.fd_pipe = -1, \
 }
 
-/// @brief Print out a debug message.
-#define printfd(format, ...) \
-  (fprintf(stdout, format "\n", ## __VA_ARGS__), fflush(stdout))
-
 /// @brief Print out a debug message with function name.
-#define printfdf(format, ...) \
-  (fprintf(stdout, "%s" format "\n", __func__, ## __VA_ARGS__), fflush(stdout))
-
-/// @brief Print out an error message.
-#define printfe(format, ...) \
-  (fprintf(stderr, format "\n", ## __VA_ARGS__), fflush(stderr))
+#define printfdf(alwaysprint, format, ...) \
+  ((alwaysprint) || (debuglog))? fprintf(stdout, "%s" format "\n", __func__, ## __VA_ARGS__):true;
 
 /// @brief Print out an error message with function name.
-#define printfef(format, ...) \
-  printfe("%s" format, __func__, ## __VA_ARGS__)
+#define printfef(alwaysprint, format, ...) \
+  ((alwaysprint) || (debuglog))? fprintf(stderr, "%s" format "\n", __func__, ## __VA_ARGS__):true;
 
 /// @brief Return a value if it's true.
 #define retif(x) do { if (x) return (x); } while (0)
@@ -428,7 +385,7 @@ typedef struct {
 static inline void *
 allocchk_(void *ptr, const char *func_name) {
   if (unlikely(!ptr)) {
-    printfe("%s(): Failed to allocate memory.", func_name);
+    printfef(true, "%s(): Failed to allocate memory.", func_name);
 	exit(RET_BADALLOC);
   }
 
@@ -523,7 +480,7 @@ print_timestamp(session_t *ps) {
 
 	timeval_subtract(&diff, &tm, &ps->time_start);
 
-	printf("[ %5ld.%02ld ] ", diff.tv_sec, diff.tv_usec / 10000);
+	printfef(false, "[ %5ld.%02ld ] ", diff.tv_sec, diff.tv_usec / 10000);
 }
 
 /**
@@ -885,7 +842,7 @@ check_keysyms(const char *str_err_prefix1, const char *str_err_prefix2, const ch
 		KeySym keysym = key_str_sym(word);
 
 		if (!keysym)
-			printfef("(): %s%s \"%s\" was not recognized as a valid KeySym. Run the program 'xev' to find the correct value.", str_err_prefix1, str_err_prefix2, word);
+			printfef(true, "(): %s%s \"%s\" was not recognized as a valid KeySym. Run the program 'xev' to find the correct value.", str_err_prefix1, str_err_prefix2, word);
 
 		free(word);
   }
@@ -985,7 +942,7 @@ keysyms_arr_keycodes(Display *display, KeySym *keysyms, KeyCode **dest)
   for (int i = 0; i < num_keysyms; i++)
   {
     arr_keycodes[i] = XKeysymToKeycode(display, keysyms[i]);
-    // fprintf(stdout, "i=%i, keysym=%i, keycode=(0x%02lx)\n", i, keysyms[i], arr_keycodes[i]);
+    printfdf(false, "(): i=%i, keysym=%lu, keycode=(0x%02i)", i, keysyms[i], arr_keycodes[i]);
     count++;
   }
   // fputs("\n", stdout); fflush(stdout);
@@ -1096,9 +1053,8 @@ check_keybindings_conflict(const char *config_path, const char *arr1_str, KeySym
     for (int i = 0; i < num_conflicts; i++)
     {
       KeySym keysym = conflicts[i];
-      printfef("(): %s: [bindings] Conflict detected. Remove the duplicate setting. Keybinding: '%s' found in both '%s' and '%s'.", config_path, XKeysymToString(keysym), arr1_str, arr2_str);
-      // fprintf(stdout, "%s   (0x%02lx)\n", XKeysymToString(keysym), keysym);
-      // fputs("\n", stdout);
+      printfdf(true, "(): %s: [bindings] Conflict detected. Remove the duplicate setting. Keybinding: '%s' found in both '%s' and '%s'.", config_path, XKeysymToString(keysym), arr1_str, arr2_str);
+      printfdf(true, "%s   (0x%02lx)\n", XKeysymToString(keysym), keysym);
     }
     free(conflicts);
     return true;
@@ -1108,15 +1064,15 @@ check_keybindings_conflict(const char *config_path, const char *arr1_str, KeySym
 }
 
 #define report_key(ev) \
-	printfef("(): Key %u (%s) occured.", (ev)->xkey.keycode, \
+	printfdf(false, "(): Key %u (%s) occured.", (ev)->xkey.keycode, \
 			ev_key_str(&(ev)->xkey))
 
 #define report_key_ignored(ev) \
-	printfef("(): KeyRelease %u (%s) ignored.", (ev)->xkey.keycode, \
+	printfdf(false, "(): KeyRelease %u (%s) ignored.", (ev)->xkey.keycode, \
 			ev_key_str(&(ev)->xkey))
 
 #define report_key_unbinded(ev) \
-	printfef("(): KeyRelease %u (%s) not binded to anything.", \
+	printfdf(false, "(): KeyRelease %u (%s) not binded to anything.", \
 			(ev)->xkey.keycode, ev_key_str(&(ev)->xkey))
 
 
@@ -1230,10 +1186,10 @@ check_modmasks(const char *str_err_prefix1, const char *str_err_prefix2, const c
 			break;
 
 		int modkeymask = str_key_modifier_int(word);
-		// fprintf(stdout, "%s  %i (0x%02lx)\n", word, modkeymask, modkeymask);
+		printfdf(false, "(): %s  %i (0x%02i)", word, modkeymask, modkeymask);
 
 		if (!modkeymask)
-			printfef("(): %s%s \"%s\" not recognized as a Modifier Key Mask. See: /usr/include/X11/X.h", str_err_prefix1, str_err_prefix2, word);
+			printfef(true, "(): %s%s \"%s\" not recognized as a Modifier Key Mask. See: /usr/include/X11/X.h", str_err_prefix1, str_err_prefix2, word);
 
 		free(word);
   }
@@ -1275,7 +1231,7 @@ modkeymasks_str_enums(const char *s, int** dest)
 	  break;
 
 	int modkeymask = str_key_modifier_int(word);
-	// fprintf(stdout, "%s  %i (0x%02lx)\n", word, modkeymask, modkeymask);
+	printfdf(false, "(): %s  %i (0x%02i)", word, modkeymask, modkeymask);
 
 	// only increment the array counter if the modifier key mask is valid
 	if(modkeymask)
@@ -1316,22 +1272,20 @@ arr_modkeymasks_includes(int *arr_modkeymasks, int modkeymask)
 /**
  * @brief Print a log message if the keyboard event has a modifier key held down
  */
-static inline int
+static inline void
 report_key_modifiers(XKeyEvent *evk)
 {
   // fputs("report_key_modifiers(XKeyEvent *evk)\n", stdout);
-  if (!evk) return 0;
+  if (!evk) return;
 
-  int result = 0;
   int i = 0;
   while (ev_modifier_mask[i])
   {
     if (evk->state & ev_modifier_mask[i])
-      result = printfef("(): Key modifier (%s) is held for key (%s).", ev_modifier_mask_str[i], ev_key_str(evk));
+      printfdf(false,"(): Key modifier (%s) is held for key (%s).", ev_modifier_mask_str[i], ev_key_str(evk));
     i++;
   }
   // fputs("\n", stdout);
-  return result;
 }
 
 #include "img.h"

--- a/src/tooltip.c
+++ b/src/tooltip.c
@@ -88,7 +88,7 @@ tooltip_create(MainWin *mw) {
 	}
 
 	if (!tt->window) {
-		printfef("(): WARNING: Couldn't create tooltip window.");
+		printfef(false, "(): WARNING: Couldn't create tooltip window.");
 		tooltip_destroy(tt);
 		return 0;
 	}
@@ -97,7 +97,7 @@ tooltip_create(MainWin *mw) {
 	tmp = ps->o.tooltip_border;
 	if(! XftColorAllocName(ps->dpy, mw->visual, mw->colormap, tmp, &tt->border))
 	{
-		fprintf(stderr, "WARNING: Invalid color '%s'.\n", tmp);
+		printfef(false, "WARNING: Invalid color '%s'.\n", tmp);
 		tooltip_destroy(tt);
 		return 0;
 	}
@@ -105,7 +105,7 @@ tooltip_create(MainWin *mw) {
 	tmp = ps->o.tooltip_background;
 	if(! XftColorAllocName(ps->dpy, mw->visual, mw->colormap, tmp, &tt->background))
 	{
-		fprintf(stderr, "WARNING: Invalid color '%s'.\n", tmp);
+		printfef(false, "WARNING: Invalid color '%s'.\n", tmp);
 		tooltip_destroy(tt);
 		return 0;
 	}
@@ -117,7 +117,7 @@ tooltip_create(MainWin *mw) {
 	tmp = ps->o.tooltip_text;
 	if(! XftColorAllocName(ps->dpy, mw->visual, mw->colormap, tmp, &tt->color))
 	{
-		fprintf(stderr, "WARNING: Couldn't allocate color '%s'.\n", tmp);
+		printfef(false, "WARNING: Couldn't allocate color '%s'.\n", tmp);
 		tooltip_destroy(tt);
 		return 0;
 	}
@@ -127,7 +127,7 @@ tooltip_create(MainWin *mw) {
 	{
 		if(! XftColorAllocName(ps->dpy, mw->visual, mw->colormap, tmp, &tt->shadow))
 		{
-			fprintf(stderr, "WARNING: Couldn't allocate color '%s'.\n", tmp);
+			printfef(false, "WARNING: Couldn't allocate color '%s'.\n", tmp);
 			tooltip_destroy(tt);
 			return 0;
 		}
@@ -136,7 +136,7 @@ tooltip_create(MainWin *mw) {
 	tt->draw = XftDrawCreate(ps->dpy, tt->window, mw->visual, mw->colormap);
 	if(! tt->draw)
 	{
-		fprintf(stderr, "WARNING: Couldn't create Xft draw surface.\n");
+		printfef(false, "WARNING: Couldn't create Xft draw surface.\n");
 		tooltip_destroy(tt);
 		return 0;
 	}
@@ -144,7 +144,7 @@ tooltip_create(MainWin *mw) {
 	tt->font = XftFontOpenName(ps->dpy, ps->screen, ps->o.tooltip_font);
 	if(! tt->font)
 	{
-		fprintf(stderr, "WARNING: Couldn't open Xft font.\n");
+		printfef(false, "WARNING: Couldn't open Xft font.\n");
 		tooltip_destroy(tt);
 		return 0;
 	}
@@ -203,8 +203,6 @@ tooltip_map(Tooltip *tt, int mouse_x, int mouse_y,
 
 void
 tooltip_move(Tooltip *tt, int mouse_x, int mouse_y) {
-
-	// printfdf("(): x=%i y=%i",mouse_x,mouse_y);
 
 	session_t *ps = tt->mainwin->ps;
 	int x = ps->o.tooltip_offsetX, y = ps->o.tooltip_offsetY;

--- a/src/tooltip.c
+++ b/src/tooltip.c
@@ -97,7 +97,7 @@ tooltip_create(MainWin *mw) {
 	tmp = ps->o.tooltip_border;
 	if(! XftColorAllocName(ps->dpy, mw->visual, mw->colormap, tmp, &tt->border))
 	{
-		printfef(false, "WARNING: Invalid color '%s'.\n", tmp);
+		printfef(false, "(): WARNING: Invalid color '%s'.\n", tmp);
 		tooltip_destroy(tt);
 		return 0;
 	}
@@ -105,7 +105,7 @@ tooltip_create(MainWin *mw) {
 	tmp = ps->o.tooltip_background;
 	if(! XftColorAllocName(ps->dpy, mw->visual, mw->colormap, tmp, &tt->background))
 	{
-		printfef(false, "WARNING: Invalid color '%s'.\n", tmp);
+		printfef(false, "(): WARNING: Invalid color '%s'.\n", tmp);
 		tooltip_destroy(tt);
 		return 0;
 	}
@@ -117,7 +117,7 @@ tooltip_create(MainWin *mw) {
 	tmp = ps->o.tooltip_text;
 	if(! XftColorAllocName(ps->dpy, mw->visual, mw->colormap, tmp, &tt->color))
 	{
-		printfef(false, "WARNING: Couldn't allocate color '%s'.\n", tmp);
+		printfef(false, "(): WARNING: Couldn't allocate color '%s'.\n", tmp);
 		tooltip_destroy(tt);
 		return 0;
 	}
@@ -127,7 +127,7 @@ tooltip_create(MainWin *mw) {
 	{
 		if(! XftColorAllocName(ps->dpy, mw->visual, mw->colormap, tmp, &tt->shadow))
 		{
-			printfef(false, "WARNING: Couldn't allocate color '%s'.\n", tmp);
+			printfef(false, "(): WARNING: Couldn't allocate color '%s'.\n", tmp);
 			tooltip_destroy(tt);
 			return 0;
 		}
@@ -136,7 +136,7 @@ tooltip_create(MainWin *mw) {
 	tt->draw = XftDrawCreate(ps->dpy, tt->window, mw->visual, mw->colormap);
 	if(! tt->draw)
 	{
-		printfef(false, "WARNING: Couldn't create Xft draw surface.\n");
+		printfef(false, "(): WARNING: Couldn't create Xft draw surface.\n");
 		tooltip_destroy(tt);
 		return 0;
 	}
@@ -144,7 +144,7 @@ tooltip_create(MainWin *mw) {
 	tt->font = XftFontOpenName(ps->dpy, ps->screen, ps->o.tooltip_font);
 	if(! tt->font)
 	{
-		printfef(false, "WARNING: Couldn't open Xft font.\n");
+		printfef(false, "(): WARNING: Couldn't open Xft font.\n");
 		tooltip_destroy(tt);
 		return 0;
 	}

--- a/src/wm.c
+++ b/src/wm.c
@@ -511,11 +511,11 @@ printfdfWindowName(session_t *ps, char *prefix_str, Window wid)
 		return;
 
 	if (prefix_str) {
-		printfdf(false, "%s%s", prefix_str, win_title);
+		printfdf(false, "(): %s%s", prefix_str, win_title);
 	}
 
 	else {
-		printfdf(false, "%s", win_title);
+		printfdf(false, "(): %s", win_title);
 	}
 
 	free(win_title);

--- a/src/wm.c
+++ b/src/wm.c
@@ -347,14 +347,14 @@ wm_get_stack_sub(session_t *ps, Window root) {
 		// EWMH
 		l = wm_get_stack_fromprop(ps, root, _NET_CLIENT_LIST);
 		if (l) {
-			//printfef("(): Retrieved window stack from _NET_CLIENT_LIST.");
+			printfdf(false, "(): Retrieved window stack from _NET_CLIENT_LIST.");
 			return l;
 		}
 
 		// GNOME WM
 		l = wm_get_stack_fromprop(ps, root, _WIN_CLIENT_LIST);
 		if (l) {
-			//printfef("(): Retrieved window stack from _WIN_CLIENT_LIST.");
+			printfdf(false, "(): Retrieved window stack from _WIN_CLIENT_LIST.");
 			return l;
 		}
 	}
@@ -384,7 +384,7 @@ wm_get_stack_sub(session_t *ps, Window root) {
 			}
 		}
 		sxfree(children);
-		//printfef("(): Retrieved window stack by querying all children.");
+		printfdf(false, "(): Retrieved window stack by querying all children.");
 	}
 
 	return l;
@@ -502,7 +502,7 @@ wm_get_window_title(session_t *ps, Window wid, int *length_return) {
 }
 
 void
-printfefWindowName(session_t *ps, char *prefix_str, Window wid)
+printfdfWindowName(session_t *ps, char *prefix_str, Window wid)
 {
 	int win_title_len = 0;
 	FcChar8 *win_title = wm_get_window_title(ps, wid, &win_title_len);
@@ -510,11 +510,13 @@ printfefWindowName(session_t *ps, char *prefix_str, Window wid)
 	if (! win_title)
 		return;
 
-	if (prefix_str)
-		printfef("%s%s", prefix_str, win_title);
+	if (prefix_str) {
+		printfdf(false, "%s%s", prefix_str, win_title);
+	}
 
-	else
-		printfef("%s", win_title);
+	else {
+		printfdf(false, "%s", win_title);
+	}
 
 	free(win_title);
 }
@@ -673,10 +675,10 @@ wm_get_focused(session_t *ps) {
 	{
 		int revert_to = 0;
 		if (!XGetInputFocus(ps->dpy, &focused, &revert_to)) {
-			printfef("(): Failed to get current focused window.");
+			printfdf(false, "(): Failed to get current focused window.");
 			return None;
 		}
-		// printfdf("(): Focused window is %#010lx.", focused);
+		printfdf(false, "(): Focused window is %#010lx.", focused);
 	}
 
 	while (focused) {
@@ -698,10 +700,10 @@ wm_get_focused(session_t *ps) {
 				XQueryTree(ps->dpy, focused, &rroot, &parent, &children, &nchildren);
 			sxfree(children);
 			if (!status) {
-				printfef("(): Failed to get parent window of %#010lx.", focused);
+				printfef(false, "(): Failed to get parent window of %#010lx.", focused);
 				return None;
 			}
-			// printfdf("(): Parent window of %#010lx is %#010lx.", focused, parent);
+			printfdf(false, "(): Parent window of %#010lx is %#010lx.", focused, parent);
 			focused = parent;
 			assert(ps->root == rroot);
 		}

--- a/src/wm.h
+++ b/src/wm.h
@@ -67,15 +67,15 @@ static inline bool
 wm_check(session_t *ps) {
 	if (wm_check_netwm(ps)) {
 		ps->wmpsn = WMPSN_EWMH;
-		printfdf("(): Your WM looks EWMH compliant.");
+		printfdf(true, "(): Your WM looks EWMH compliant.");
 		return true;
 	}
 	if (wm_check_gnome(ps)) {
 		ps->wmpsn = WMPSN_GNOME;
-		printfdf("(): Your WM looks GNOME compliant.");
+		printfdf(true, "(): Your WM looks GNOME compliant.");
 		return true;
 	}
-	printfef("(): Your WM is neither EWMH nor GNOME WM compliant. "
+	printfdf(true, "(): Your WM is neither EWMH nor GNOME WM compliant. "
 			"Troubles ahead.");
 	return false;
 }
@@ -85,7 +85,7 @@ Pixmap wm_get_root_pmap(Display *dpy);
 unsigned long wm_get_desktops(session_t *ps);
 long wm_get_current_desktop(session_t *ps);
 FcChar8 *wm_get_window_title(session_t *ps, Window wid, int *length_return);
-void printfefWindowName(session_t *ps, char *prefix_str, Window wid);
+void printfdfWindowName(session_t *ps, char *prefix_str, Window wid);
 Window wm_get_group_leader(Display *dpy, Window window);
 void wm_set_fullscreen(session_t *ps, Window window,
 		int x, int y, unsigned width, unsigned height);


### PR DESCRIPTION
Finally tidying up all the debug and error prints

There are two boolean parameters for printing, alwaysprint and debuglog. alwaysprint is specified in the code by developers. debuglog is specified at runtime by command line parameter '-S'. They combine by this matrix:

-- | alwaysprint | alwaysprint
-- | -- | --
debuglog | 0 | 1
0 | silent | print
1 | print | print

The principle is that printfdf() prints information for debugging; printfef() prints error information.

alwaysprint is reserved for information that an end user needs to see. E.g.:

config_load(): config file found. using "/home/felix/.config/skippy-xd/skippy-xd.rc"
wm_check(): Your WM looks EWMH compliant.