### PR TITLE
Animation always at 60 fps

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -896,7 +896,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 				if (layout != LAYOUTMODE_SWITCHER
 						&& timeslice < ps->o.animationDuration
 						&& timeslice + first_animated >=
-						last_rendered + ps->mainwin->poll_time) {
+						last_rendered + (1000.0 / 60.0)) {
 					anime(ps->mainwin, ps->mainwin->clients,
 						((float)timeslice)/(float)ps->o.animationDuration);
 					last_rendered = time_in_millis();


### PR DESCRIPTION
Previously animation fps was tied to updateFreq config option value, which is the background polling frequency.

It makes more sense to decouple the two.

I am hardcoding animation to 60 fps, since even 30 fps look notably uneven.