### PR TITLE
Fix segfault when no windows on all desktops

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -721,6 +721,10 @@ skippy_activate(MainWin *mw, Window leader, enum layoutmode layout)
 	mw->client_to_focus = NULL;
 
 	daemon_count_clients(mw, 0, leader);
+	if (!mw->clients || !mw->clientondesktop) {
+		return false;
+	}
+
 	foreach_dlist(mw->clients) {
 		clientwin_update((ClientWin *) iter->data);
 		clientwin_update2((ClientWin *) iter->data);


### PR DESCRIPTION
This also changes app behaviour a bit:

Old:
- When there are no windows on current virtual desktop, app activates with no mini window
- When there are no windows on all virtual desktops, app segfaults

New:
- When there are no windows on current virtual desktop, app does not activate
- When there are no windows on all virtual desktops, app does not activate