### PR TITLE
Always focus on some window via XSetInputFocus()

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -854,6 +854,7 @@ mainloop(session_t *ps, bool activate_on_start) {
 					wm_set_desktop_ewmh(ps, mw->client_to_focus->slots);
 					XSync(ps->dpy, True);
 					XSync(ps->dpy, False);
+					XSetInputFocus(ps->dpy, PointerRoot, RevertToPointerRoot, CurrentTime);
 				}
 				childwin_focus(mw->client_to_focus);
 				mw->client_to_focus = NULL;

--- a/src/wm.c
+++ b/src/wm.c
@@ -675,8 +675,12 @@ wm_get_focused(session_t *ps) {
 	{
 		int revert_to = 0;
 		if (!XGetInputFocus(ps->dpy, &focused, &revert_to)) {
-			printfdf(false, "(): Failed to get current focused window.");
-			return None;
+			printfdf(false, "(): Currently not focused on any window; trying to find focus...");
+			XSetInputFocus(ps->dpy, PointerRoot, RevertToPointerRoot, CurrentTime);
+			if (!XGetInputFocus(ps->dpy, &focused, &revert_to)) {
+				printfdf(false, "(): Failed to get current focused window.");
+				return None;
+			}
 		}
 		printfdf(false, "(): Focused window is %#010lx.", focused);
 	}


### PR DESCRIPTION
After lots of work on xlib, looks like XSetInputFocus(PointerRoot) is the way to focus on top window on current virtual desktop...