### PR TITLE
Paging updates thumbnail

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -852,9 +852,10 @@ mainloop(session_t *ps, bool activate_on_start) {
 
 			// Focus the client window only after the main window get unmapped and
 			// keyboard gets ungrabbed.
+			long new_desktop = -1;
 			if (mw->client_to_focus) {
 				if (layout == LAYOUTMODE_PAGING)
-					wm_set_desktop_ewmh(ps, mw->client_to_focus->slots);
+					new_desktop = mw->client_to_focus->slots;
 				childwin_focus(mw->client_to_focus);
 				mw->client_to_focus = NULL;
 				refocus = false;
@@ -887,6 +888,9 @@ mainloop(session_t *ps, bool activate_on_start) {
 			XSync(ps->dpy, True);
 
 			mw = NULL;
+
+			if (new_desktop != -1)
+				wm_set_desktop_ewmh(ps, new_desktop);
 		}
 		if (!mw)
 			die = false;

--- a/src/wm.h
+++ b/src/wm.h
@@ -149,12 +149,6 @@ wm_set_desktop_ewmh(session_t *ps, long desktop) {
 	long data[] = { desktop, CurrentTime };
 	wm_send_clientmsg_ewmh_root(ps, ps->root, _NET_CURRENT_DESKTOP,
 			CARR_LEN(data), data);
-
-	XChangeProperty(ps->dpy, ps->root,
-			XInternAtom(ps->dpy, "_NET_CURRENT_DESKTOP", False),
-			XA_CARDINAL, 32, PropModeReplace, (unsigned char *) &desktop, 1);
-	XSync(ps->dpy, True);
-	XSync(ps->dpy, False);
 }
 
 /**


### PR DESCRIPTION
I compared the xlib code that switches virtual desktop with that in xdotool (which I verified works properly in terms of updating thumbnail and also always sets focus to top window on current virtual desktop). The code over here and that in xdotool are virtually identical. When I copy/paste the code from xdotool to wm_set_desktop_ewmh(), the behaviour of skippy-xd, in particular #106 and #112 remained.

Hence, it looks like it is not wm_set_desktop_ewmh() that needs updating (the code also conforms to https://specifications.freedesktop.org/wm-spec/latest/ar01s03.html#idm45820873325616). It is perhaps some sort of nuance in how wm_set_desktop_ewmh() is called with some timing dependency or something... I don't know.

This PR seems to fix #112 without fixing #106. Anyone know the reason please let me know :P