### PR TITLE
Proper Z-order for switcher

### DIFF
--- a/src/layout.c
+++ b/src/layout.c
@@ -43,8 +43,14 @@ void layout_run(MainWin *mw, dlist *windows,
 	if (layout == LAYOUTMODE_EXPOSE
 			&& mw->ps->o.exposeLayout == LAYOUT_BOXY)
 		layout_boxy(mw, windows, total_width, total_height);
-	else
+	else {
+		// to get the proper z-order based window ordering,
+		// reversing the list of windows is needed
+		dlist_reverse(windows);
 		layout_xd(mw, windows, total_width, total_height);
+		// reversing the linked list again for proper focus ordering
+		dlist_reverse(windows);
+	}
 }
 
 // original legacy layout

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -914,7 +914,8 @@ mainloop(session_t *ps, bool activate_on_start) {
 						mainwin_map(mw);
 					XFlush(ps->dpy);
 				}
-				else if (timeslice >= ps->o.animationDuration) {
+				else if (layout == LAYOUTMODE_SWITCHER
+						|| timeslice >= ps->o.animationDuration) {
 					anime(ps->mainwin, ps->mainwin->clients, 1);
 					animating = false;
 					last_rendered = time_in_millis();

--- a/src/wm.c
+++ b/src/wm.c
@@ -343,7 +343,8 @@ static inline dlist *
 wm_get_stack_sub(session_t *ps, Window root) {
 	dlist *l = NULL;
 
-	if (!(ps->o.acceptOvRedir || ps->o.acceptWMWin)) {
+	// does not give info on windows z-order
+	/*if (!(ps->o.acceptOvRedir || ps->o.acceptWMWin)) {
 		// EWMH
 		l = wm_get_stack_fromprop(ps, root, _NET_CLIENT_LIST);
 		if (l) {
@@ -357,9 +358,9 @@ wm_get_stack_sub(session_t *ps, Window root) {
 			printfdf(false, "(): Retrieved window stack from _WIN_CLIENT_LIST.");
 			return l;
 		}
-	}
+	}*/
 
-	// Stupid method
+	// Stupid method, but this gives windows ordered by z-order
 	{
 		Window *children = NULL;
 		unsigned nchildren = 0;


### PR DESCRIPTION
With this changes, switcher (alt-tab) follows proper z-order of windows, that is, the window layout is ordered top-bottom, left-right, with latest focused windows ordered first.

E.g. window configurations:

[1] [2]
[3] [4]

with window [4] being the latest touched window etc.

Switcher gives this layout:

[4] [3]
[2] [1]

with focus order [4]->[3]->[2]->[1]

Expose gives this layout:

[1] [2]
[3] [4]

with focus order [1]->[3]->[2]->[4]

z-ordering preservation of paging works on a different code path, init_paging_layout(), and is still in progress.

@dreamcat4 can you please test this, since you use skippy like alt-tab?