### PR TITLE
Remove config options

### DIFF
--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -62,7 +62,6 @@ lazyTrans = false
 pipePath = /tmp/skippy-xd-fifo
 
 distance = 50
-useNetWMFullscreen = true
 ignoreSkipTaskbar = true
 updateFreq = 60.0
 

--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -9,9 +9,6 @@
 # - colors can be anything XAllocNamedColor can handle
 #   (like "black" or "#000000")
 #
-# - distance is a relative number, and is scaled according to the scale
-#   factor applied to windows
-#
 # - fonts are Xft font descriptions
 #
 # - booleans are "true" or anything but "true" (-> false)
@@ -19,13 +16,6 @@
 # - opacity is an integer in the range of 0-255
 #
 # - brightness is a floating point number (with 0.0 as neutral)
-#
-# - if the update frequency is a negative value, the mini-windows will only
-#   be updated when they're explicitly rendered (like, when they gain or
-#   lose focus). otherwise updateFreq is how many updates per second (fps)
-#
-# - the 'shadowText' option can be a color or 'none', in which case the
-#   drop-shadow effect is disabled
 #
 # - Picture specification:
 #   [WIDTHxHEIGHT] [orig|scale|scalek|tile] [left|mid|right] [left|mid|right]

--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -57,6 +57,10 @@
 
 [general]
 
+background =
+lazyTrans = false
+pipePath = /tmp/skippy-xd-fifo
+
 distance = 50
 useNetWMFullscreen = true
 ignoreSkipTaskbar = true
@@ -64,9 +68,6 @@ updateFreq = 60.0
 
 # set = 0 to switch off animations
 animationDuration = 200
-
-lazyTrans = false
-pipePath = /tmp/skippy-xd-fifo
 
 # exposeLayout=xd uses the same layout as switcher, maximizing screen estate
 # exposeLayout=boxy tends to preserve window positions, thus guiding the eye more
@@ -78,11 +79,11 @@ exposeShowAllDesktops = false
 # Move the mouse cursor when skippy is activated
 movePointer = false
 
-switchDesktopOnActivate = false
 includeFrame = true
 allowUpscale = true
 
-# Choose whether to show minimized windows
+# Choose whether to show shadow windows: windows that are minimized,
+# shaded, or on other virtual desktops
 showShadow = true
 
 cornerRadius = 5
@@ -90,7 +91,6 @@ preferredIconSize = 48
 showIconsOnThumbnails = true
 iconFillSpec = orig mid mid #00FFFF
 fillSpec = orig mid mid #FFFFFF
-background =
 
 [xinerama]
 showAll = true

--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -155,5 +155,3 @@ keysExitCancelOnPress = Escape BackSpace x q
 keysExitCancelOnRelease =
 keysExitSelectOnPress = Return space
 keysExitSelectOnRelease = Super_L Super_R Alt_L Alt_R ISO_Level3_Shift
-keysReverseDirection = Tab
-modifierKeyMasksReverseDirection = ShiftMask ControlMask

--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -18,7 +18,7 @@
 #
 # - opacity is an integer in the range of 0-255
 #
-# - brighness is a floating point number (with 0.0 as neutral)
+# - brightness is a floating point number (with 0.0 as neutral)
 #
 # - if the update frequency is a negative value, the mini-windows will only
 #   be updated when they're explicitly rendered (like, when they gain or
@@ -31,7 +31,7 @@
 #   [WIDTHxHEIGHT] [orig|scale|scalek|tile] [left|mid|right] [left|mid|right]
 #   [COLOR|#FFFFFFFF] [PATH]
 #
-# - keysUp, keywDown, eysLeft, keysRight:
+# - keysUp, keysDown, keysLeft, keysRight:
 #   selects the window in the direction compared to the current selected window,
 #   without wrapping
 #
@@ -57,34 +57,54 @@
 
 [general]
 
-background =
-lazyTrans = false
+# File path of skippy-xd pipe daemon communication
 pipePath = /tmp/skippy-xd-fifo
 
-distance = 50
+# Background picture when skippy-xd is activated
+background =
+
+# Frequency to update pixmaps
 updateFreq = 60.0
 
-# set = 0 to switch off animations
+# Allow other compositors such as picom handle transparency
+lazyTrans = false
+
+# Move the mouse cursor when skippy is activated
+movePointer = false
+
+# Set = 0 to switch off animations
+# for switch, there is never animation
 animationDuration = 200
+
+# Relative minimal distance between windows
+distance = 50
+
+# Whether to display window frames
+includeFrame = true
+
+# Whether to show the window bigger than its original size
+allowUpscale = true
+
+# Choose whether to show shadow windows:
+# windows that are minimized, shaded, or on other virtual desktops
+showShadow = true
 
 # exposeLayout=xd uses the same layout as switcher, maximizing screen estate
 # exposeLayout=boxy tends to preserve window positions, thus guiding the eye more
 exposeLayout = boxy
 
+# For switch and expose,
+# Whether to limit window select on current virtual desktop
+# Or allow window selection on all virtual desktops
+# Paging always show all desktops
 switchShowAllDesktops = true
 exposeShowAllDesktops = false
 
-# Move the mouse cursor when skippy is activated
-movePointer = false
-
-includeFrame = true
-allowUpscale = true
-
-# Choose whether to show shadow windows: windows that are minimized,
-# shaded, or on other virtual desktops
-showShadow = true
-
+# Show window previews with rounded corners,
+# with corner radius in pixels
 cornerRadius = 5
+
+# Icon visual parameters
 preferredIconSize = 48
 showIconsOnThumbnails = true
 iconFillSpec = orig mid mid #00FFFF

--- a/skippy-xd.sample.rc
+++ b/skippy-xd.sample.rc
@@ -62,7 +62,6 @@ lazyTrans = false
 pipePath = /tmp/skippy-xd-fifo
 
 distance = 50
-ignoreSkipTaskbar = true
 updateFreq = 60.0
 
 # set = 0 to switch off animations

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -590,58 +590,34 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 		report_key_modifiers(evk);
 		if (debuglog) fputs("\n", stdout);
 
-		bool reverse_direction = false;
-
-		if (arr_modkeymasks_includes(cw->mainwin->modifierKeyMasks_ReverseDirection, evk->state))
-			if(arr_keycodes_includes(cw->mainwin->keycodes_ReverseDirection, evk->keycode))
-				reverse_direction = true;
-
 		if (arr_keycodes_includes(cw->mainwin->keycodes_Up, evk->keycode))
 		{
-			if(reverse_direction)
-				focus_down(cw);
-			else
-				focus_up(cw);
+            focus_up(cw);
 		}
 
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_Down, evk->keycode))
 		{
-			if(reverse_direction)
-				focus_up(cw);
-			else
-				focus_down(cw);
+            focus_down(cw);
 		}
 
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_Left, evk->keycode))
 		{
-			if(reverse_direction)
-				focus_right(cw);
-			else
-				focus_left(cw);
+            focus_left(cw);
 		}
 
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_Right, evk->keycode))
 		{
-			if(reverse_direction)
-				focus_left(cw);
-			else
-				focus_right(cw);
+            focus_right(cw);
 		}
 
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_Prev, evk->keycode))
 		{
-			if(reverse_direction)
-				focus_miniw_next(ps, cw);
-			else
-				focus_miniw_prev(ps, cw);
+            focus_miniw_prev(ps, cw);
 		}
 
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_Next, evk->keycode))
 		{
-			if(reverse_direction)
-				focus_miniw_prev(ps, cw);
-			else
-				focus_miniw_next(ps, cw);
+            focus_miniw_next(ps, cw);
 		}
 
 		else if (arr_keycodes_includes(cw->mainwin->keycodes_ExitCancelOnPress, evk->keycode))

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -150,10 +150,6 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	keys_str_syms(ps->o.bindings_keysExitCancelOnRelease, &mw->keysyms_ExitCancelOnRelease);
 	keys_str_syms(ps->o.bindings_keysExitSelectOnPress, &mw->keysyms_ExitSelectOnPress);
 	keys_str_syms(ps->o.bindings_keysExitSelectOnRelease, &mw->keysyms_ExitSelectOnRelease);
-	keys_str_syms(ps->o.bindings_keysReverseDirection, &mw->keysyms_ReverseDirection);
-
-	// convert the modifier key masks settings strings into arrays of enums
-	modkeymasks_str_enums(ps->o.bindings_modifierKeyMasksReverseDirection, &mw->modifierKeyMasks_ReverseDirection);
 
 	// convert the arrays of KeySyms into arrays of KeyCodes, for this specific Display
 	keysyms_arr_keycodes(dpy, mw->keysyms_Up, &mw->keycodes_Up);
@@ -166,7 +162,6 @@ mainwin_reload(session_t *ps, MainWin *mw) {
 	keysyms_arr_keycodes(dpy, mw->keysyms_ExitCancelOnRelease, &mw->keycodes_ExitCancelOnRelease);
 	keysyms_arr_keycodes(dpy, mw->keysyms_ExitSelectOnPress, &mw->keycodes_ExitSelectOnPress);
 	keysyms_arr_keycodes(dpy, mw->keysyms_ExitSelectOnRelease, &mw->keycodes_ExitSelectOnRelease);
-	keysyms_arr_keycodes(dpy, mw->keysyms_ReverseDirection, &mw->keycodes_ReverseDirection);
 
 	// we check all possible pairs, one pair at a time. This is in a specific order, to give a more helpful error msg
 	check_keybindings_conflict(ps->o.config_path, "keysUp", mw->keysyms_Up, "keysDown", mw->keysyms_Down);
@@ -480,9 +475,6 @@ mainwin_destroy(MainWin *mw) {
 	free(mw->keysyms_ExitCancelOnRelease);
 	free(mw->keysyms_ExitSelectOnPress);
 	free(mw->keysyms_ExitSelectOnRelease);
-	free(mw->keysyms_ReverseDirection);
-
-	free(mw->modifierKeyMasks_ReverseDirection);
 
 	free(mw->keycodes_Up);
 	free(mw->keycodes_Down);
@@ -494,7 +486,6 @@ mainwin_destroy(MainWin *mw) {
 	free(mw->keycodes_ExitCancelOnRelease);
 	free(mw->keycodes_ExitSelectOnPress);
 	free(mw->keycodes_ExitSelectOnRelease);
-	free(mw->keycodes_ReverseDirection);
 
 	free(mw);
 }

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -63,9 +63,6 @@ struct _mainwin_t {
 	KeySym *keysyms_ExitCancelOnRelease;
 	KeySym *keysyms_ExitSelectOnPress;
 	KeySym *keysyms_ExitSelectOnRelease;
-	KeySym *keysyms_ReverseDirection;
-
-	int *modifierKeyMasks_ReverseDirection;
 
 	KeyCode *keycodes_Up;
 	KeyCode *keycodes_Down;
@@ -77,7 +74,6 @@ struct _mainwin_t {
 	KeyCode *keycodes_ExitCancelOnRelease;
 	KeyCode *keycodes_ExitSelectOnPress;
 	KeyCode *keycodes_ExitSelectOnRelease;
-	KeyCode *keycodes_ReverseDirection;
 
 	bool mapped;
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1684,7 +1684,6 @@ load_config_file(session_t *ps)
 
     config_get_int_wrap(config, "general", "distance", &ps->o.distance, 1, INT_MAX);
     config_get_bool_wrap(config, "general", "useNetWMFullscreen", &ps->o.useNetWMFullscreen);
-    config_get_bool_wrap(config, "general", "ignoreSkipTaskbar", &ps->o.ignoreSkipTaskbar);
     config_get_bool_wrap(config, "general", "acceptOvRedir", &ps->o.acceptOvRedir);
     config_get_bool_wrap(config, "general", "acceptWMWin", &ps->o.acceptWMWin);
     config_get_double_wrap(config, "general", "updateFreq", &ps->o.updateFreq, -1000.0, 1000.0);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1642,8 +1642,6 @@ load_config_file(session_t *ps)
     ps->o.bindings_keysExitCancelOnRelease = mstrdup(config_get(config, "bindings", "keysExitCancelOnRelease", ""));
     ps->o.bindings_keysExitSelectOnPress = mstrdup(config_get(config, "bindings", "keysExitSelectOnPress", "Return space"));
     ps->o.bindings_keysExitSelectOnRelease = mstrdup(config_get(config, "bindings", "keysExitSelectOnRelease", "Super_L Super_R Alt_L Alt_R ISO_Level3_Shift"));
-    ps->o.bindings_keysReverseDirection = mstrdup(config_get(config, "bindings", "keysReverseDirection", "Tab"));
-    ps->o.bindings_modifierKeyMasksReverseDirection = mstrdup(config_get(config, "bindings", "modifierKeyMasksReverseDirection", "ShiftMask ControlMask"));
 
     // print an error message for any key bindings that aren't recognized
     check_keysyms(ps->o.config_path, ": [bindings] keysUp =", ps->o.bindings_keysUp);
@@ -1656,8 +1654,6 @@ load_config_file(session_t *ps)
     check_keysyms(ps->o.config_path, ": [bindings] keysExitCancelOnRelease =", ps->o.bindings_keysExitCancelOnRelease);
     check_keysyms(ps->o.config_path, ": [bindings] keysExitSelectOnPress =", ps->o.bindings_keysExitSelectOnPress);
     check_keysyms(ps->o.config_path, ": [bindings] keysExitSelectOnRelease =", ps->o.bindings_keysExitSelectOnRelease);
-    check_keysyms(ps->o.config_path, ": [bindings] keysReverseDirection =", ps->o.bindings_keysReverseDirection);
-    check_modmasks(ps->o.config_path, ": [bindings] modifierKeyMasksReverseDirection =", ps->o.bindings_modifierKeyMasksReverseDirection);
 
 	if (!parse_cliop(ps, config_get(config, "bindings", "miwMouse1", "focus"), &ps->o.bindings_miwMouse[1])
 			|| !parse_cliop(ps, config_get(config, "bindings", "miwMouse2", "close-ewmh"), &ps->o.bindings_miwMouse[2])
@@ -1939,8 +1935,6 @@ main_end:
 			free(ps->o.bindings_keysExitCancelOnRelease);
 			free(ps->o.bindings_keysExitSelectOnPress);
 			free(ps->o.bindings_keysExitSelectOnRelease);
-			free(ps->o.bindings_keysReverseDirection);
-			free(ps->o.bindings_modifierKeyMasksReverseDirection);
 		}
 
 		if (ps->fd_pipe >= 0)

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1698,7 +1698,6 @@ load_config_file(session_t *ps)
     config_get_bool_wrap(config, "general", "exposeShowAllDesktops", &ps->o.exposeShowAllDesktops);
     config_get_bool_wrap(config, "general", "showShadow", &ps->o.showShadow);
     config_get_bool_wrap(config, "general", "movePointer", &ps->o.movePointer);
-    config_get_bool_wrap(config, "general", "switchDesktopOnActivate", &ps->o.switchDesktopOnActivate);
     config_get_bool_wrap(config, "xinerama", "showAll", &ps->o.xinerama_showAll);
     config_get_int_wrap(config, "normal", "tintOpacity", &ps->o.normal_tintOpacity, 0, 256);
     config_get_int_wrap(config, "normal", "opacity", &ps->o.normal_opacity, 0, 256);

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -204,7 +204,6 @@ typedef struct {
 	bool includeFrame;
 	char *pipePath;
 	bool movePointer;
-	bool switchDesktopOnActivate;
 	bool allowUpscale;
 	bool switchShowAllDesktops;
 	bool exposeShowAllDesktops;
@@ -276,7 +275,6 @@ typedef struct {
 	.includeFrame = false, \
 	.pipePath = NULL, \
 	.movePointer = false, \
-	.switchDesktopOnActivate = false, \
 	.allowUpscale = true, \
 	.cornerRadius = 0, \
 	.preferredIconSize = 48, \

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -195,7 +195,6 @@ typedef struct {
 	int exposeLayout;
 	int distance;
 	bool useNetWMFullscreen;
-	bool ignoreSkipTaskbar;
 	bool acceptOvRedir;
 	bool acceptWMWin;
 	double updateFreq;
@@ -266,7 +265,6 @@ typedef struct {
 	.exposeLayout = LAYOUT_BOXY, \
 	.distance = 50, \
 	.useNetWMFullscreen = true, \
-	.ignoreSkipTaskbar = false, \
 	.acceptOvRedir = false, \
 	.acceptWMWin = false, \
 	.updateFreq = 60.0, \

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -253,8 +253,6 @@ typedef struct {
 	char *bindings_keysExitCancelOnRelease;
 	char *bindings_keysExitSelectOnPress;
 	char *bindings_keysExitSelectOnRelease;
-	char *bindings_keysReverseDirection;
-	char *bindings_modifierKeyMasksReverseDirection;
 } options_t;
 
 #define OPTIONST_INIT { \

--- a/src/wm.c
+++ b/src/wm.c
@@ -560,7 +560,7 @@ void
 wm_set_fullscreen(session_t *ps, Window window,
 		int x, int y, unsigned width, unsigned height) {
 	Display *dpy = ps->dpy;
-	if (ps->o.useNetWMFullscreen && ps->has_ewmh_fullscreen) {
+	if (ps->has_ewmh_fullscreen) {
 		Atom props[] = {
 			_NET_WM_STATE_FULLSCREEN,
 			_NET_WM_STATE_SKIP_TASKBAR,

--- a/src/wm.c
+++ b/src/wm.c
@@ -609,8 +609,7 @@ wm_validate_window(session_t *ps, Window wid) {
 			long v = prop.data32[i];
 			if (!ps->o.showShadow && _NET_WM_STATE_HIDDEN == v)
 				result = false;
-			else if (ps->o.ignoreSkipTaskbar
-					&& _NET_WM_STATE_SKIP_TASKBAR == v)
+			else if (_NET_WM_STATE_SKIP_TASKBAR == v)
 				result = false;
 			else if (_NET_WM_STATE_SHADED == v)
 				result = false;
@@ -626,7 +625,7 @@ wm_validate_window(session_t *ps, Window wid) {
 			result = false;
 		free_winprop(&prop);
 
-		if (result && ps->o.ignoreSkipTaskbar) {
+		if (result) {
 			prop = wid_get_prop(ps, wid, _WIN_HINTS, 1, XA_CARDINAL, 0);
 			if (winprop_get_int(&prop) & WIN_HINTS_SKIP_TASKBAR)
 				result = false;

--- a/src/wm.h
+++ b/src/wm.h
@@ -158,11 +158,6 @@ static inline void
 wm_activate_window(session_t *ps, Window wid) {
 	if (!wid) return;
 
-	if (ps->o.switchDesktopOnActivate) {
-		long tgt = wm_get_window_desktop(ps, wid);
-		if (tgt >= 0)
-			wm_set_desktop_ewmh(ps, tgt);
-	}
 	// Order is important, to avoid "intelligent" WMs fixing our focus stealing
 	wm_activate_window_ewmh(ps, wid);
 	XSetInputFocus(ps->dpy, wid, RevertToParent, CurrentTime);


### PR DESCRIPTION
Remove some config options, which are either never used or always defaulted as true.

Out of these, the most "dangerous" (as in perhaps potentially erroneously removed) is keysReverseDirection and modifierKeyMasksReverseDirection, which according to my code inspection is never used. Anyhow, alternative ways to set up Alt-Tab and Shift-Alt-Tab exists.